### PR TITLE
Add text support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ env/
 target/
 __pycache__/
 *.so
+uv.lock

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -724,6 +724,24 @@ impl Transaction {
         tx.unmark(obj_id.0, name, start, end, expand.into())
             .map_err(|e| PyException::new_err(e.to_string()))
     }
+
+    fn splice_text(
+        &mut self,
+        obj_id: PyObjId,
+        pos: usize,
+        delete_count: isize,
+        text: &str,
+    ) -> PyResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+        let Some(tx) = inner.tx.as_mut() else {
+            return Err(PyException::new_err("transaction no longer active"));
+        };
+        tx.splice_text(obj_id.0, pos, delete_count, text)
+            .map_err(|e| PyException::new_err(e.to_string()))
+    }
 }
 
 fn datetime_to_timestamp(datetime: &Bound<'_, PyDateTime>) -> PyResult<i64> {

--- a/src/automerge/__init__.py
+++ b/src/automerge/__init__.py
@@ -1,3 +1,12 @@
-from .document import Document
+from ._automerge import ROOT, ObjType, ScalarType
+from .document import Document, ImmutableString, MutableText, Text
 
-__all__ = ['Document']
+__all__ = [
+    "Document",
+    "ImmutableString",
+    "ROOT",
+    "ObjType",
+    "ScalarType",
+    "Text",
+    "MutableText",
+]

--- a/src/automerge/document.py
+++ b/src/automerge/document.py
@@ -1,25 +1,44 @@
-import automerge.core as core
-from datetime import datetime
-from typing import Iterator, cast, Mapping, Sequence, MutableMapping, MutableSequence, overload, Iterable, List, Union, Tuple, Optional
 from contextlib import contextmanager
+from datetime import datetime
+from typing import (
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
+
+import automerge.core as core
+
 
 class ActorId:
     def __init__(self, id: bytes):
         self.id = id
 
     @staticmethod
-    def random() -> 'ActorId':
+    def random() -> "ActorId":
         return ActorId(core.random_actor_id())
-    
+
+
 class ObjectId:
     def __init__(self, id: bytes):
         self.id = id
-        
+
+
 class ChangeHash:
     def __init__(self, hash: bytes):
         self.hash = hash
 
-ProxyThing = Union[core.ScalarValue, Mapping[str, 'ProxyThing'], Sequence['ProxyThing']]
+
+ProxyThing = Union[core.ScalarValue, Mapping[str, "ProxyThing"], Sequence["ProxyThing"]]
+
 
 class ReadProxy:
     _doc: core.Document
@@ -30,14 +49,16 @@ class ReadProxy:
         self._doc = doc
         self._obj_id = obj_id
         self._heads = heads
-        
+
     def __len__(self) -> int:
         return self._doc.length(self._obj_id, self._heads)
 
     def to_py(self) -> core.Thing:
         return core.extract(self._doc, self._obj_id)
 
-    def _maybe_wrap(self, x: Tuple[core.Value, bytes]) -> 'MapReadProxy | ListReadProxy | core.ScalarValue':
+    def _maybe_wrap(
+        self, x: Tuple[core.Value, bytes]
+    ) -> "MapReadProxy | ListReadProxy | core.ScalarValue":
         value, obj_id = x
         if isinstance(value, core.ObjType):
             if value == core.ObjType.List:
@@ -48,32 +69,44 @@ class ReadProxy:
         _, v = value
         return v
 
+
 class MapReadProxy(ReadProxy, Mapping[str, ProxyThing]):
-    def __getitem__(self, key: str) -> 'MapReadProxy | ListReadProxy | core.ScalarValue':
+    def __getitem__(
+        self, key: str
+    ) -> "MapReadProxy | ListReadProxy | core.ScalarValue":
         x = self._doc.get(self._obj_id, key, self._heads)
-        if x is None: raise IndexError()
+        if x is None:
+            raise IndexError()
         return self._maybe_wrap(x)
-    
+
     def __iter__(self) -> Iterator[str]:
         return iter(self._doc.keys(self._obj_id, self._heads))
+
 
 class ListReadProxy(ReadProxy, Sequence[ProxyThing]):
     @overload
     def __getitem__(self, key: int) -> ProxyThing: ...
     @overload
     def __getitem__(self, key: slice) -> Sequence[ProxyThing]: ...
-    def __getitem__(self, key: Union[int, slice]) -> Union[ProxyThing, Sequence[ProxyThing]]:
-        if not isinstance(key, int): raise NotImplemented
+    def __getitem__(
+        self, key: Union[int, slice]
+    ) -> Union[ProxyThing, Sequence[ProxyThing]]:
+        if not isinstance(key, int):
+            raise NotImplemented
         x = self._doc.get(self._obj_id, key, self._heads)
-        if x is None: raise IndexError()
+        if x is None:
+            raise IndexError()
         return self._maybe_wrap(x)
-    
+
+
 class WriteProxy:
     _tx: core.Transaction
     _obj_id: bytes
     _heads: Optional[List[bytes]]
-    
-    def __init__(self, tx: core.Transaction, obj_id: bytes, heads: Optional[List[bytes]]) -> None:
+
+    def __init__(
+        self, tx: core.Transaction, obj_id: bytes, heads: Optional[List[bytes]]
+    ) -> None:
         self._tx = tx
         self._obj_id = obj_id
         self._heads = heads
@@ -81,14 +114,144 @@ class WriteProxy:
     def __len__(self) -> int:
         return self._tx.length(self._obj_id, self._heads)
 
-MutableProxyThing = Union[core.ScalarValue, MutableMapping[str, 'MutableProxyThing'], MutableSequence['MutableProxyThing']]
+    def _infer_scalar_type_for_key(
+        self,
+        key: Union[str, int],
+        value: core.ScalarValue,
+        default_type: core.ScalarType,
+    ) -> core.ScalarType:
+        """
+        Infer the scalar type to use for a value, preserving existing type if present.
+
+        Args:
+            key: The key or index where the value will be stored
+            value: The scalar value being stored
+            default_type: The type to use if there's no existing value or it can be inferred
+
+        Returns:
+            The scalar type to use for storage
+        """
+        x = self._tx.get(self._obj_id, key, self._heads)
+        if x is None:
+            return default_type
+        else:
+            val, _ = x
+            if isinstance(val, core.ObjType):
+                return default_type
+            else:
+                t, _ = val
+                return t
+
+    def _insert_value(
+        self,
+        key: Union[str, int],
+        value: "MutableProxyThing",
+        operation: str = "put",
+    ) -> None:
+        """
+        Insert a value into the document, handling type detection and object creation.
+
+        Args:
+            key: The key (string) or index (int) where to insert
+            value: The value to insert
+            operation: One of "put", "insert", or "put_or_insert"
+                - "put": Always use put/put_object
+                - "insert": Always use insert/insert_object
+                - "put_or_insert": Use insert if index >= length, else put (for lists)
+        """
+        if isinstance(value, MutableMapping):
+            obj_id = self._create_object(key, core.ObjType.Map, operation)
+            m = MapWriteProxy(self._tx, obj_id, self._heads)
+            for k, dv in value.items():
+                m[k] = dv
+        elif isinstance(value, MutableSequence):
+            obj_id = self._create_object(key, core.ObjType.List, operation)
+            l = ListWriteProxy(self._tx, obj_id, self._heads)
+            for i, lv in enumerate(value):
+                l[i] = lv
+        else:  # scalar
+            value = cast(core.ScalarValue, value)
+            t = self._infer_scalar_type_for_key(key, value, _infer_scalar_type(value))
+            self._put_scalar(key, t, value, operation)
+
+    def _create_object(
+        self, key: Union[str, int], obj_type: core.ObjType, operation: str
+    ) -> bytes:
+        """
+        Create an object in the document based on the operation type.
+
+        Args:
+            key: The key or index where to create the object
+            obj_type: The type of object to create
+            operation: "put", "insert", or "put_or_insert"
+
+        Returns:
+            The object ID of the created object
+        """
+        if operation == "put":
+            return self._tx.put_object(self._obj_id, key, obj_type)
+        elif operation == "insert":
+            return self._tx.insert_object(self._obj_id, key, obj_type)
+        elif operation == "put_or_insert":
+            if isinstance(key, int) and key >= self._tx.length(
+                self._obj_id, self._heads
+            ):
+                return self._tx.insert_object(self._obj_id, key, obj_type)
+            else:
+                return self._tx.put_object(self._obj_id, key, obj_type)
+        else:
+            raise ValueError(f"Unknown operation: {operation}")
+
+    def _put_scalar(
+        self,
+        key: Union[str, int],
+        scalar_type: core.ScalarType,
+        value: core.ScalarValue,
+        operation: str,
+    ) -> None:
+        """
+        Put a scalar value into the document based on the operation type.
+
+        Args:
+            key: The key or index where to put the value
+            scalar_type: The type of the scalar value
+            value: The scalar value to put
+            operation: "put", "insert", or "put_or_insert"
+        """
+        if operation == "put":
+            self._tx.put(self._obj_id, key, scalar_type, value)
+        elif operation == "insert":
+            self._tx.insert(self._obj_id, key, scalar_type, value)
+        elif operation == "put_or_insert":
+            if isinstance(key, int) and key >= self._tx.length(
+                self._obj_id, self._heads
+            ):
+                self._tx.insert(self._obj_id, key, scalar_type, value)
+            else:
+                self._tx.put(self._obj_id, key, scalar_type, value)
+        else:
+            raise ValueError(f"Unknown operation: {operation}")
+
+
+# Forward declaration for TextWriteProxy
+class TextWriteProxy: ...
+
+
+MutableProxyThing = Union[
+    core.ScalarValue,
+    MutableMapping[str, "MutableProxyThing"],
+    MutableSequence["MutableProxyThing"],
+    "TextWriteProxy",
+]
+
 
 class MapWriteProxy(WriteProxy, MutableMapping[str, MutableProxyThing]):
     _tx: core.Transaction
 
     def __getitem__(self, key: Union[str, int]) -> MutableProxyThing:
         x = self._tx.get(self._obj_id, key, self._heads)
-        if x is None: return None
+        if x is None:
+            return None
         value, obj_id = x
         if isinstance(value, core.ObjType):
             if value == core.ObjType.Map:
@@ -98,46 +261,30 @@ class MapWriteProxy(WriteProxy, MutableMapping[str, MutableProxyThing]):
             raise Exception("unknown ObjType")
         _, v = value
         return v
-    
+
     def __setitem__(self, key: str, value: MutableProxyThing) -> None:
-        if isinstance(value, MutableMapping):
-            obj_id = self._tx.put_object(self._obj_id, key, core.ObjType.Map)
-            m = MapWriteProxy(self._tx, obj_id, self._heads)
-            for k, dv in value.items():
-                m[k] = dv
-        elif isinstance(value, MutableSequence):
-            obj_id = self._tx.put_object(self._obj_id, key, core.ObjType.List)
-            l = ListWriteProxy(self._tx, obj_id, self._heads)
-            for i, lv in enumerate(value):
-                l[i] = lv
-        else: # scalar
-            # Don't change the type of the value if there's already a value here.
-            x = self._tx.get(self._obj_id, key, self._heads)
-            if x is None:
-                t = _infer_scalar_type(value)
-            else:
-                val, _ = x
-                if isinstance(val, core.ObjType):
-                    t = _infer_scalar_type(value)
-                else:
-                    t, _ = val
-            self._tx.put(self._obj_id, key, t, value)
-            
+        self._insert_value(key, value, operation="put")
+
     def __delitem__(self, key: str) -> None:
         self._tx.delete(self._obj_id, key)
-        
+
     def __iter__(self) -> Iterator[str]:
         raise NotImplemented
+
 
 class ListWriteProxy(WriteProxy, MutableSequence[MutableProxyThing]):
     @overload
     def __getitem__(self, key: int) -> MutableProxyThing: ...
     @overload
     def __getitem__(self, key: slice) -> MutableSequence[MutableProxyThing]: ...
-    def __getitem__(self, key: Union[int, slice]) -> Union[MutableProxyThing, MutableSequence[MutableProxyThing]]:
-        if not isinstance(key, int): raise NotImplemented
+    def __getitem__(
+        self, key: Union[int, slice]
+    ) -> Union[MutableProxyThing, MutableSequence[MutableProxyThing]]:
+        if not isinstance(key, int):
+            raise NotImplemented
         x = self._tx.get(self._obj_id, key, self._heads)
-        if x is None: return None
+        if x is None:
+            return None
         value, obj_id = x
         if isinstance(value, core.ObjType):
             if value == core.ObjType.Map:
@@ -147,82 +294,43 @@ class ListWriteProxy(WriteProxy, MutableSequence[MutableProxyThing]):
             raise Exception("unknown ObjType")
         _, v = value
         return v
-    
+
     @overload
     def __setitem__(self, key: int, value: MutableProxyThing) -> None: ...
     @overload
     def __setitem__(self, key: slice, value: Iterable[MutableProxyThing]) -> None: ...
-    def __setitem__(self, idx: Union[int, slice], value: Union[MutableProxyThing, Iterable[MutableProxyThing]]) -> None:
-        if not isinstance(idx, int): raise NotImplemented
-        if isinstance(value, MutableMapping):
-            if idx >= self._tx.length(self._obj_id, self._heads):
-                obj_id = self._tx.insert_object(self._obj_id, idx, core.ObjType.Map)
-            else:
-                obj_id = self._tx.put_object(self._obj_id, idx, core.ObjType.Map)
-            m = MapWriteProxy(self._tx, obj_id, self._heads)
-            for k, dv in value.items():
-                m[k] = dv
-        elif isinstance(value, MutableSequence):
-            if idx >= self._tx.length(self._obj_id, self._heads):
-                obj_id = self._tx.insert_object(self._obj_id, idx, core.ObjType.List)
-            else:
-                obj_id = self._tx.put_object(self._obj_id, idx,
-                                             core.ObjType.List)
-            l = ListWriteProxy(self._tx, obj_id, self._heads)
-            for i, lv in enumerate(cast(MutableSequence[MutableProxyThing], value)):
-                l[i] = lv
-        else: # scalar
-            # Don't change the type of the value if there's already a value here.
-            value = cast(core.ScalarValue, value)
-            x = self._tx.get(self._obj_id, idx, self._heads)
-            if x is None:
-                t = _infer_scalar_type(value)
-            else:
-                val, _ = x
-                if isinstance(val, core.ObjType):
-                    t = _infer_scalar_type(value)
-                else:
-                    t, _ = val
-            if idx >= self._tx.length(self._obj_id, self._heads):
-                self._tx.insert(self._obj_id, idx, t, value)
-            else:
-                self._tx.put(self._obj_id, idx, t, value)
+    def __setitem__(
+        self,
+        idx: Union[int, slice],
+        value: Union[MutableProxyThing, Iterable[MutableProxyThing]],
+    ) -> None:
+        if not isinstance(idx, int):
+            raise NotImplemented
+        self._insert_value(idx, value, operation="put_or_insert")
 
     @overload
     def __delitem__(self, idx: int) -> None: ...
     @overload
     def __delitem__(self, idx: slice) -> None: ...
     def __delitem__(self, idx: Union[int, slice]) -> None:
-        if not isinstance(idx, int): raise NotImplemented
+        if not isinstance(idx, int):
+            raise NotImplemented
         self._tx.delete(self._obj_id, idx)
-        
-    def insert(self, idx: int, value: Union[core.ScalarValue, MutableMapping[str, MutableProxyThing], MutableSequence[MutableProxyThing], None]) -> None:
-        if not isinstance(idx, int): raise NotImplemented
-        if isinstance(value, MutableMapping):
-            obj_id = self._tx.insert_object(self._obj_id, idx, core.ObjType.Map)
-            m = MapWriteProxy(self._tx, obj_id, self._heads)
-            for k, dv in value.items():
-                m[k] = dv
-        elif isinstance(value, MutableSequence):
-            obj_id = self._tx.insert_object(self._obj_id, idx, core.ObjType.List)
-            l = ListWriteProxy(self._tx, obj_id, self._heads)
-            for i, lv in enumerate(value):
-                l[i] = lv
-        else: # scalar
-            # Don't change the type of the value if there's already a value here.
-            x = self._tx.get(self._obj_id, idx, self._heads)
-            if x is None:
-                t = _infer_scalar_type(value)
-            else:
-                val, _ = x
-                if isinstance(val, core.ObjType):
-                    t = _infer_scalar_type(value)
-                else:
-                    t, _ = val
-            if idx >= self._tx.length(self._obj_id, self._heads):
-                self._tx.insert(self._obj_id, idx, t, value)
-            else:
-                self._tx.put(self._obj_id, idx, t, value)
+
+    def insert(
+        self,
+        idx: int,
+        value: Union[
+            core.ScalarValue,
+            MutableMapping[str, MutableProxyThing],
+            MutableSequence[MutableProxyThing],
+            None,
+        ],
+    ) -> None:
+        if not isinstance(idx, int):
+            raise NotImplemented
+        self._insert_value(idx, value, operation="insert")
+
 
 def _infer_scalar_type(value: core.ScalarValue) -> core.ScalarType:
     if isinstance(value, str):
@@ -246,9 +354,8 @@ class Document(MapReadProxy):
     def __init__(self, actor_id: Optional[ActorId] = None) -> None:
         self._doc = core.Document(actor_id.id if actor_id else None)
         super().__init__(self._doc, core.ROOT, None)
-        
+
     @contextmanager
     def change(self) -> Iterator[MapWriteProxy]:
         with self._doc.transaction() as tx:
             yield MapWriteProxy(tx, core.ROOT, None)
-    

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,38 +1,44 @@
 from automerge import Document
 
+
 def test_doc() -> None:
     doc = Document()
     with doc.change() as c:
-        c['hello'] = 'world'
+        c["hello"] = "world"
 
-    assert doc['hello'] == 'world'
-    
+    assert str(doc["hello"]) == "world"
+
+
 def test_doc_import_obj() -> None:
     doc = Document()
     with doc.change() as c:
-        c['hello'] = {'this': {'is': 'a', 'whole': 'tree'}, 'of': [{'obj': 'ect'}, 's']}
-        
-    assert doc.to_py() == {'hello': {'this': {'is': 'a', 'whole': 'tree'}, 'of': [{'obj': 'ect'}, 's']}}
-    
+        c["hello"] = {"this": {"is": "a", "whole": "tree"}, "of": [{"obj": "ect"}, "s"]}
+
+    assert doc.to_py() == {
+        "hello": {"this": {"is": "a", "whole": "tree"}, "of": [{"obj": "ect"}, "s"]}
+    }
+
+
 def test_nested_import() -> None:
     doc = Document()
     with doc.change() as c:
-        c['hello'] = {}
-        c['hello']['foo'] = 'bar'
-        
-    assert doc.to_py() == {'hello': {'foo': 'bar'}}
+        c["hello"] = {}
+        c["hello"]["foo"] = "bar"
+
+    assert doc.to_py() == {"hello": {"foo": "bar"}}
     {}.__getitem__
-    
+
+
 def test_iterable() -> None:
     doc = Document()
     with doc.change() as c:
-        c['list'] = [1, 2, 3]
-        c['map'] = {
-            'k': 'v',
-            'x': 'y',
+        c["list"] = [1, 2, 3]
+        c["map"] = {
+            "k": "v",
+            "x": "y",
         }
-    assert len(doc['list']) == 3
-    assert list(doc['list']) == [1, 2, 3]
-    assert len(doc['map']) == 2
-    assert list(doc['map']) == ['k', 'x']
-    assert list(doc['map'].items()) == [('k', 'v'), ('x', 'y')]
+    assert len(doc["list"]) == 3
+    assert list(doc["list"]) == [1, 2, 3]
+    assert len(doc["map"]) == 2
+    assert list(doc["map"]) == ["k", "x"]
+    assert list(doc["map"].items()) == [("k", "v"), ("x", "y")]

--- a/tests/test_immutable_string.py
+++ b/tests/test_immutable_string.py
@@ -1,0 +1,43 @@
+import pytest
+from automerge import ImmutableString
+
+
+def test_immutable_string_creation():
+    """Test that ImmutableString can be created"""
+    s = ImmutableString("test")
+    assert s == "test"
+
+
+def test_immutable_string_is_instance_of_str():
+    """Test that ImmutableString is an instance of str"""
+    s = ImmutableString("test")
+    assert isinstance(s, str)
+    assert isinstance(s, ImmutableString)
+
+
+def test_immutable_string_behaves_like_string():
+    """Test that ImmutableString has normal string behavior"""
+    s = ImmutableString("hello")
+
+    # Test basic string operations
+    assert len(s) == 5
+    assert s.upper() == "HELLO"
+    assert s[0] == "h"
+    assert s[1:3] == "el"
+    assert s + " world" == "hello world"
+    assert "ell" in s
+
+
+def test_immutable_string_with_unicode():
+    """Test that ImmutableString works with Unicode strings"""
+    s = ImmutableString("hello 世界")
+    assert s == "hello 世界"
+    assert isinstance(s, ImmutableString)
+
+
+def test_immutable_string_empty():
+    """Test that ImmutableString works with empty strings"""
+    s = ImmutableString("")
+    assert s == ""
+    assert len(s) == 0
+    assert isinstance(s, ImmutableString)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,481 @@
+import pytest
+
+import automerge.core as core
+from automerge import Document, ImmutableString
+
+
+class TestTextCreation:
+    """Test creating Text objects via maps and lists"""
+
+    def test_map_string_creates_text(self):
+        """Assigning a string to a map creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            d["content"] = "Hello, world!"
+
+        text = doc["content"]
+        assert type(text).__name__ == "Text"
+        assert str(text) == "Hello, world!"
+
+    def test_map_immutable_string_creates_scalar(self):
+        """Assigning an ImmutableString to a map creates a scalar string"""
+        doc = Document()
+        with doc.change() as d:
+            d["version"] = ImmutableString("1.0.0")
+
+        version = doc["version"]
+        assert type(version).__name__ == "str"
+        assert version == "1.0.0"
+
+    def test_list_string_creates_text(self):
+        """Assigning a string to a list creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            d["items"] = []
+            d["items"][0] = "First item"
+
+        text = doc["items"][0]
+        assert type(text).__name__ == "Text"
+        assert str(text) == "First item"
+
+    def test_list_immutable_string_creates_scalar(self):
+        """Assigning an ImmutableString to a list creates a scalar string"""
+        doc = Document()
+        with doc.change() as d:
+            d["tags"] = []
+            d["tags"][0] = ImmutableString("alpha")
+
+        tag = doc["tags"][0]
+        assert type(tag).__name__ == "str"
+        assert tag == "alpha"
+
+    def test_list_insert_string_creates_text(self):
+        """Inserting a string into a list creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            d["messages"] = []
+            d["messages"].insert(0, "Hello")
+
+        text = doc["messages"][0]
+        assert type(text).__name__ == "Text"
+        assert str(text) == "Hello"
+
+    def test_assigning_write_proxy_to_map_field(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            # create a text object
+            d["text"] = "Hello"
+            d["text2"] = d["text"]
+
+    def test_assigning_read_proxy_to__map_field_works(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        otherdoc = Document()
+        with otherdoc.change() as d:
+            d["text"] = "hello"
+
+        doc = Document()
+        with doc.change() as d2:
+            d2["text"] = otherdoc["text"]
+
+        assert doc["text"] == "hello"
+
+    def test_appending_write_proxy_to_string(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"][0] = d["text"]
+            assert d["list"][0] == "hello"
+
+        assert doc["list"][0] == "hello"
+
+    def test_inserting_write_proxy_in_string(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"].insert(0, d["text"])
+            assert d["list"][0] == "hello"
+
+        assert doc["list"][0] == "hello"
+
+    def test_inserting_write_proxy_in_string(self):
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"].insert(0, d["text"])
+            assert d["list"][0] == "hello"
+
+        assert doc["list"][0] == "hello"
+
+    def test_updating_write_proxy_in_string(self):
+        otherdoc = Document()
+        with otherdoc.change() as d:
+            d["text"] = "hello"
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"][0] = 1
+            d["list"].insert(0, otherdoc["text"])
+            assert d["list"][0] == "hello"
+            assert len(d["list"]) == 2
+
+        assert doc["list"][0] == "hello"
+
+    def test_inserting_read_proxy_in_string(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        otherdoc = Document()
+        with otherdoc.change() as d:
+            d["text"] = "hello"
+
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"][0] = otherdoc["text"]
+            assert d["list"][0] == "hello"
+
+        assert doc["list"][0] == "hello"
+
+    def test_updating_read_proxy_in_string(self):
+        """Assigning a Text object to a new field creates a Text object"""
+        otherdoc = Document()
+        with otherdoc.change() as d:
+            d["text"] = "hello"
+
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "hello"
+            d["list"] = []
+            d["list"][0] = 1
+            d["list"][0] = otherdoc["text"]
+            assert d["list"][0] == "hello"
+            assert len(d["list"]) == 1
+
+        assert doc["list"][0] == "hello"
+
+
+class TestTextReadOperations:
+    """Test reading Text objects"""
+
+    def test_text_str(self):
+        """Text objects can be converted to strings"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        assert str(doc["text"]) == "Hello, world!"
+
+    def test_text_eq_str(self):
+        """Text objects can be compared to strings"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        assert doc["text"] == "Hello, world!"
+        assert doc["text"] != "something else"
+
+    def test_text_len(self):
+        """Text objects have length"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+
+        assert len(doc["text"]) == 5
+
+    def test_text_indexing(self):
+        """Text objects support indexing"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+
+        assert doc["text"][0] == "H"
+        assert doc["text"][1] == "e"
+        assert doc["text"][-1] == "o"
+
+    def test_text_slicing(self):
+        """Text objects support slicing"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        assert doc["text"][0:5] == "Hello"
+        assert doc["text"][7:12] == "world"
+        assert doc["text"][:5] == "Hello"
+        assert doc["text"][7:] == "world!"
+
+    def test_text_repr(self):
+        """Text objects have a useful repr"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+
+        repr_str = repr(doc["text"])
+        assert "Text(" in repr_str
+        assert "Hello" in repr_str
+
+
+class TestTextWriteOperations:
+    """Test mutating Text objects"""
+
+    def test_text_insert(self):
+        """Text objects support insert operation"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        with doc.change() as d:
+            d["text"].insert(7, "Python ")
+
+        assert str(doc["text"]) == "Hello, Python world!"
+
+    def test_text_eq_str(self):
+        """Text objects can be compared to strings"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+            assert d["text"] == "Hello, world!"
+            assert d["text"] != "something else"
+
+    def test_text_delete(self):
+        """Text objects support delete operation"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        with doc.change() as d:
+            d["text"].delete(5, 8)  # Delete ", world!"
+
+        assert str(doc["text"]) == "Hello"
+
+    def test_text_splice(self):
+        """Text objects support splice operation"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello, world!"
+
+        with doc.change() as d:
+            d["text"].splice(0, 5, "Goodbye")  # Replace "Hello" with "Goodbye"
+
+        assert str(doc["text"]) == "Goodbye, world!"
+
+    def test_multiple_edits_in_transaction(self):
+        """Multiple text edits in one transaction"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+            d["text"].insert(5, ", world")
+            d["text"].insert(12, "!")
+
+        assert str(doc["text"]) == "Hello, world!"
+
+    def test_text_mutation_within_list(self):
+        """Text objects in lists can be mutated"""
+        doc = Document()
+        with doc.change() as d:
+            d["items"] = []
+            d["items"][0] = "First"
+
+        with doc.change() as d:
+            d["items"][0].insert(5, " Item")
+
+        assert str(doc["items"][0]) == "First Item"
+
+
+class TestTextEdgeCases:
+    """Test edge cases with Text objects"""
+
+    def test_empty_string(self):
+        """Empty strings create valid Text objects"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = ""
+
+        text = doc["text"]
+        assert type(text).__name__ == "Text"
+        assert str(text) == ""
+        assert len(text) == 0
+
+    def test_unicode_text(self):
+        """Unicode strings work correctly"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello 世界 🌍"
+
+        assert str(doc["text"]) == "Hello 世界 🌍"
+
+    def test_unicode_insert(self):
+        """Inserting unicode text works"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+
+        with doc.change() as d:
+            d["text"].insert(5, " 世界")
+
+        assert str(doc["text"]) == "Hello 世界"
+
+    def test_very_long_string(self):
+        """Long strings work correctly"""
+        long_text = "a" * 10000
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = long_text
+
+        assert str(doc["text"]) == long_text
+        assert len(doc["text"]) == 10000
+
+    def test_newlines_in_text(self):
+        """Text with newlines works"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Line 1\nLine 2\nLine 3"
+
+        assert str(doc["text"]) == "Line 1\nLine 2\nLine 3"
+
+    def test_special_characters(self):
+        """Special characters work correctly"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Special: \t\n\r\\ \"quotes\" 'apostrophes'"
+
+        assert "\t" in str(doc["text"])
+        assert "\n" in str(doc["text"])
+
+
+class TestTextRemoteEdits:
+    """Test Text objects reflect changes"""
+
+    def test_proxy_reflects_subsequent_edits(self):
+        """Text proxy reflects edits made after getting the proxy"""
+        doc = Document()
+        with doc.change() as d:
+            d["notes"] = "Original text"
+
+        # Get a reference to the text proxy
+        my_notes = doc["notes"]
+        assert str(my_notes) == "Original text"
+
+        # Make another edit
+        with doc.change() as d:
+            d["notes"].insert(0, "Updated: ")
+
+        # The original proxy should reflect the new state
+        assert str(my_notes) == "Updated: Original text"
+
+    def test_multiple_proxies_same_text(self):
+        """Multiple proxies to same text all reflect current state"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Hello"
+
+        # Get multiple references
+        ref1 = doc["text"]
+        ref2 = doc["text"]
+
+        # Edit the text
+        with doc.change() as d:
+            d["text"].insert(5, " World")
+
+        # Both references should show the update
+        assert str(ref1) == "Hello World"
+        assert str(ref2) == "Hello World"
+
+
+class TestImmutableStringVsText:
+    """Test differences between ImmutableString and Text"""
+
+    def test_immutable_string_is_regular_str(self):
+        """ImmutableString values are plain Python strings"""
+        doc = Document()
+        with doc.change() as d:
+            d["scalar"] = ImmutableString("test")
+
+        value = doc["scalar"]
+        assert isinstance(value, str)
+        assert type(value).__name__ == "str"
+
+    def test_text_is_proxy(self):
+        """Regular string values are Text proxies"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "test"
+
+        value = doc["text"]
+        assert type(value).__name__ == "Text"
+        assert not isinstance(value, str)
+
+    def test_immutable_string_cannot_be_mutated(self):
+        """ImmutableString values don't have mutation methods"""
+        doc = Document()
+        with doc.change() as d:
+            d["scalar"] = ImmutableString("test")
+
+        value = doc["scalar"]
+        assert not hasattr(value, "insert")
+        assert not hasattr(value, "delete")
+        assert not hasattr(value, "splice")
+
+    def test_text_can_be_mutated(self):
+        """Text values have mutation methods"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "test"
+
+        with doc.change() as d:
+            text = d["text"]
+            assert hasattr(text, "insert")
+            assert hasattr(text, "delete")
+            assert hasattr(text, "splice")
+
+    def test_mixed_strings_in_document(self):
+        """Document can contain both Text and scalar strings"""
+        doc = Document()
+        with doc.change() as d:
+            d["text"] = "Editable text"
+            d["version"] = ImmutableString("1.0.0")
+            d["items"] = []
+            d["items"][0] = "Editable item"
+            d["items"][1] = ImmutableString("Immutable item")
+
+        assert type(doc["text"]).__name__ == "Text"
+        assert type(doc["version"]).__name__ == "str"
+        assert type(doc["items"][0]).__name__ == "Text"
+        assert type(doc["items"][1]).__name__ == "str"
+
+    def test_text_inheritance_and_types(self):
+        """Verify the inheritance and types of Text and MutableText."""
+        from automerge import Text, MutableText # Import here to avoid circular dependencies if Text is not fully defined yet
+
+        doc = Document()
+        with doc.change() as d:
+            d["read_text"] = "hello"
+            d["mutable_text"] = "world"
+
+        read_text_obj = doc["read_text"]
+        with doc.change() as d:
+            mutable_text_obj = d["mutable_text"]
+
+        # Verify Text object
+        assert isinstance(read_text_obj, Text)
+        assert not isinstance(read_text_obj, MutableText)
+
+        # Verify MutableText object
+        assert isinstance(mutable_text_obj, MutableText)
+        assert isinstance(mutable_text_obj, Text) # Key assertion for inheritance
+
+        # Verify attributes exist on MutableText
+        assert hasattr(mutable_text_obj, "insert")
+        assert hasattr(mutable_text_obj, "delete")
+        assert hasattr(mutable_text_obj, "splice")
+
+        # Verify attributes do not exist on read_text_obj (read-only)
+        assert not hasattr(read_text_obj, "insert")
+        assert not hasattr(read_text_obj, "delete")
+        assert not hasattr(read_text_obj, "splice")
+


### PR DESCRIPTION
This PR adds support to the high level `automerge.Document` proxy based API for the Automerge text type - which is represented in JavaScript  as a `string`. Unlike JavaScript, I have decided here to represent text as it's own class. This works out okay most of the time because we can override `__eq__` to evaluate as equal to a string, and `__str__` to display like a string. I've also added an `ImmutableString` type which allows you to specify when setting a text value that you want it to be a scalar string rather than a text collection - this is useful when you know the string won't be edited (or you don't want it to be edited).

In order to make this code easier to read I refactored the proxy handlers somewhat, this is split out into it's own commit.