### PR TITLE
ci: use macos-15-intel for x86 macos testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
           pytest
 
   macos:
-    runs-on: ${{ matrix.target == 'x86_64' && 'macos-13' || 'macos-latest' }}
+    runs-on: ${{ matrix.target == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
     strategy:
       matrix:
         target: [x86_64, aarch64]


### PR DESCRIPTION
Per [https://github.com/actions/runner-images/issues/13046] the macos-13 Github Actions runner is being discontinued and the recommendation for testing on x86 macos is to use macos-15-intel instead.