### PR TITLE
Add S3 adapter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
           install: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip pytest
+            pip3 install -U pip pytest pytest-asyncio
           run: |
             set -e
             pip3 install automerge --find-links dist --force-reinstall --no-index

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: ${{ matrix.target == 'x86_64' && 'macos-13' || 'macos-latest' }}
+    runs-on: ${{ matrix.target == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
     strategy:
       matrix:
         target: [x86_64, aarch64]
@@ -148,7 +148,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: "wheels-*/*"
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1

--- a/README.md
+++ b/README.md
@@ -6,16 +6,20 @@ Python bindings for [Automerge](https://github.com/automerge/automerge).
 
 Install the bindings with `pip install automerge`.
 
+For WebSocket support (optional):
+```bash
+pip install automerge[websocket]
+```
+
 Now you can create a document and do all sorts of Automerge things with it!
 
 > [!NOTE]
-> This package currently only contains `automerge.core`, which is a low-level
-> wrapper around the [Rust automerge
-> library](https://docs.rs/automerge/latest/automerge/index.html) with few
-> concessions to ergonomics
+> This package contains both `automerge.core` (low-level wrapper) and
+> `automerge.repo` (higher-level API with sync support).
 >
-> A more ergonomic wrapper around this low-level core is currently in the
-> works.
+> The low-level `automerge.core` provides direct access to the Rust automerge
+> library. The higher-level `automerge.repo` provides document management,
+> storage, and network synchronization.
 
 ```py
 from automerge.core import Document, ROOT, ObjType, ScalarType
@@ -36,6 +40,83 @@ with doc.transaction() as tx:
 doc.merge(doc2)  # `doc` now contains {"colours": ["green", "red"]}
 ```
 
+### Using the High-Level API
+
+The `automerge.Document` class provides a more Pythonic interface using proxies:
+
+```py
+from automerge import Document, ImmutableString
+
+doc = Document()
+
+# Use Python dict/list syntax
+with doc.change() as d:
+    d["title"] = "My Document"  # Creates collaborative Text by default
+    d["version"] = ImmutableString("1.0.0")  # Use ImmutableString for non-editable strings
+    d["tags"] = []
+    d["tags"][0] = "python"
+    d["tags"][1] = "automerge"
+
+# Read values naturally
+print(doc["title"])  # TextReadProxy that acts like a string
+print(doc["version"])  # Regular Python string
+print(len(doc["tags"]))  # 2
+
+# Edit collaborative text
+with doc.change() as d:
+    d["title"].insert(0, "✨ ")  # Text objects support insert, delete, splice
+    d["tags"][0].insert(6, " 3.12")
+
+print(str(doc["title"]))  # "✨ My Document"
+```
+
+Text objects are collaborative sequences that automatically merge concurrent edits. Use `ImmutableString` when you need a simple, non-editable string value.
+
+ ### Using automerge.repo with WebSocket Sync
+ 
+ The `automerge.repo` module provides an API for managing synchronization and storage:
+ 
+ ```py
+ import asyncio
+ from automerge.repo import Repo, InMemoryStorage
+ from automerge.transports import WebSocketServer, WebSocketClientTransport
+ from automerge import ROOT, ScalarType
+ 
+ # Server side
+ async def run_server():
+     storage = InMemoryStorage()
+     repo = await Repo.load(storage)
+ 
+     async with repo:
+         async with WebSocketServer(repo, "localhost", 8080):
+             print("Server running on ws://localhost:8080")
+             await asyncio.sleep(3600)  # Keep running
+ 
+ # Client side
+ async def run_client():
+     storage = InMemoryStorage()
+     repo = await Repo.load(storage)
+ 
+     async with repo:
+         # Connect to server
+         transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+         await repo.connect(transport)
+ 
+         # Create and modify documents - changes sync automatically!
+         handle = await repo.create()
+ 
+         def update_doc(doc):
+             doc["message"] = "Hello, Automerge!"
+ 
+         await handle.change(update_doc)
+ 
+         # Read document contents using direct access
+         doc = handle.doc()
+         print(f"Message: {doc['message']}")
+ ```
+ 
+ See the [examples/](examples/) directory for more complete examples and usage patterns.
+ 
 ## Developing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ For WebSocket support (optional):
 pip install automerge[websocket]
 ```
 
+For S3 storage support (optional):
+```bash
+pip install automerge[s3]
+```
+
 Now you can create a document and do all sorts of Automerge things with it!
 
 > [!NOTE]
@@ -114,7 +119,30 @@ Text objects are collaborative sequences that automatically merge concurrent edi
  ```
  
  See the [examples/](examples/) directory for more complete examples and usage patterns.
- 
+
+### Using S3 Storage
+
+The `automerge.storages.s3` module provides S3-backed storage for persisting documents:
+
+```py
+from automerge.storages.s3 import S3Storage
+from automerge.repo import Repo
+
+# Create S3-backed storage
+storage = S3Storage(
+    bucket="my-bucket",
+    region="us-east-1",
+    prefix="users/user-123"  # Optional: isolate data by user/tenant
+)
+
+# Use exactly like any other storage
+repo = await Repo.load(storage)
+async with repo:
+    handle = await repo.create()
+    with handle.change() as doc:
+        doc["key"] = "value"
+```
+
 ## Developing
 
 ```bash
@@ -126,4 +154,81 @@ source ./env/bin/activate
 pip install maturin
 # Build the bindings
 maturin develop
+```
+
+### Testing
+
+Install test dependencies:
+
+```bash
+pip install pytest pytest-asyncio "moto[server]"
+```
+
+Run tests:
+
+```bash
+# Run all unit tests (uses moto server for S3 mocking, no AWS credentials needed)
+pytest tests/ -v
+
+# Run specific test file
+pytest tests/test_s3_storage_mock.py -v
+
+# Exclude integration tests explicitly
+pytest tests/ -m "not integration" -v
+```
+
+> **Note**: The S3 mock tests use moto's server mode (`ThreadedMotoServer`) instead of
+> decorators because aiobotocore uses aiohttp for HTTP requests, which bypasses moto's
+> standard patching. Server mode runs a local S3-compatible HTTP endpoint that works
+> correctly with async clients.
+
+#### S3 Integration Tests
+
+The S3 storage adapter has both unit tests (using moto) and integration tests against real AWS S3. Unit tests always run; integration tests are skipped unless configured.
+
+To run integration tests against real S3:
+
+```bash
+export S3_BUCKET_NAME=your-test-bucket
+export AWS_REGION=us-east-1
+export S3_TEST_PREFIX=automerge-py-tests
+pytest tests/test_s3_storage.py -v
+```
+
+#### CI Configuration
+
+For GitHub Actions, configure secrets and run integration tests conditionally:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install maturin && maturin develop
+      - run: pip install -e ".[all]" pytest pytest-asyncio "moto[server]"
+      - run: pytest tests/ -m "not integration" -v
+
+  integration:
+    runs-on: ubuntu-latest
+    # Only run on main branch or when labeled
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install maturin && maturin develop
+      - run: pip install -e ".[all]" pytest pytest-asyncio
+      - name: Run S3 integration tests
+        env:
+          S3_BUCKET_NAME: ${{ secrets.S3_TEST_BUCKET }}
+          AWS_REGION: us-east-1
+          S3_TEST_PREFIX: ci/${{ github.run_id }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: pytest tests/test_s3_storage.py -v
 ```

--- a/README.md
+++ b/README.md
@@ -104,11 +104,9 @@ Text objects are collaborative sequences that automatically merge concurrent edi
  
          # Create and modify documents - changes sync automatically!
          handle = await repo.create()
- 
-         def update_doc(doc):
-             doc["message"] = "Hello, Automerge!"
- 
-         await handle.change(update_doc)
+         
+         with handle.change() as doc:
+            doc["message"] = "Hello, Automerge!"
  
          # Read document contents using direct access
          doc = handle.doc()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,137 @@
+# Automerge Examples
+
+This directory contains example scripts demonstrating how to use automerge-py with different transports.
+
+## Prerequisites
+
+Install automerge with WebSocket support:
+
+```bash
+pip install automerge[websocket]
+```
+
+Or if you're developing:
+
+```bash
+pip install -e .[websocket]
+```
+
+## WebSocket Examples
+
+### Basic Server (`websocket_server.py`)
+
+Runs a WebSocket server that shares Automerge documents with connected clients.
+
+```bash
+python examples/websocket_server.py
+```
+
+The server will:
+- Start on `ws://localhost:8080`
+- Create an initial document
+- Accept connections from clients
+- Show the number of active connections
+
+### Basic Client (`websocket_client.py`)
+
+Connects to a WebSocket server and syncs documents.
+
+```bash
+# First, start the server in another terminal:
+python examples/websocket_server.py
+
+# Then run the client:
+python examples/websocket_client.py
+```
+
+The client will:
+- Connect to the server
+- Create a new document
+- Make changes that sync to the server
+- Show the document URL
+
+## How It Works
+
+### Server Side
+
+```python
+from automerge.repo import Repo, InMemoryStorage
+from automerge.transports import WebSocketServer
+
+# Create a repository
+storage = InMemoryStorage()
+repo = await Repo.load(storage)
+
+# Start WebSocket server
+async with repo:
+    async with WebSocketServer(repo, "localhost", 8080):
+        # Server is now running
+        await asyncio.sleep(3600)
+```
+
+### Client Side
+
+```python
+from automerge.repo import Repo, InMemoryStorage
+from automerge.transports import WebSocketClientTransport
+
+# Create a repository
+storage = InMemoryStorage()
+repo = await Repo.load(storage)
+
+# Connect to server
+async with repo:
+    transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+    await repo.connect(transport)
+```
+
+## Document Operations
+
+### Creating a Document
+
+```python
+# Create a new document
+handle = await repo.create()
+
+# Initialize with content
+def init_doc(doc):
+    doc["title"] = "Hello"
+    doc["count"] = 0
+
+await handle.change(init_doc)
+```
+
+### Reading a Document
+
+```python
+# Find a document by URL
+handle = await repo.find(url)
+
+if handle:
+    doc = handle.doc()
+    title = doc["title"]
+    print(f"Title: {title}")
+```
+
+### Modifying a Document
+
+```python
+# Make changes to a document
+def update_count(doc):
+    current = doc["count"]
+    doc["count"] = current + 1
+
+await handle.change(update_count)
+```
+
+### Important: Read vs Write Access
+
+- **Reading**: Use `doc = handle.doc()` for read-only access with Python dict-like syntax
+- **Writing**: Use `await handle.change(callback)` for mutations
+- Documents from `doc()` are read-only and will raise errors on write attempts
+- Use `change()` for all mutations
+
+## Tips
+
+- **Storage**: The examples use `InMemoryStorage` for simplicity. For production, implement a persistent storage backend.
+- **Ports**: Make sure the ports used (8080, 8081) are available on your system.

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,11 +94,9 @@ async with repo:
 handle = await repo.create()
 
 # Initialize with content
-def init_doc(doc):
+with handle.change() as doc:
     doc["title"] = "Hello"
     doc["count"] = 0
-
-await handle.change(init_doc)
 ```
 
 ### Reading a Document
@@ -117,17 +115,15 @@ if handle:
 
 ```python
 # Make changes to a document
-def update_count(doc):
+with handle.change() as doc:
     current = doc["count"]
     doc["count"] = current + 1
-
-await handle.change(update_count)
 ```
 
 ### Important: Read vs Write Access
 
 - **Reading**: Use `doc = handle.doc()` for read-only access with Python dict-like syntax
-- **Writing**: Use `await handle.change(callback)` for mutations
+- **Writing**: Use `with handle.change() as doc:` for mutations
 - Documents from `doc()` are read-only and will raise errors on write attempts
 - Use `change()` for all mutations
 

--- a/examples/websocket_client.py
+++ b/examples/websocket_client.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""WebSocket Client Example
+
+This example shows how to connect to a WebSocket server and sync Automerge
+documents.
+
+Usage:
+    # First, start the server in another terminal:
+    python examples/websocket_server.py
+
+    # Then run this client:
+    python examples/websocket_client.py
+
+The client will connect to the server and sync documents.
+"""
+
+import asyncio
+from automerge.repo import Repo, InMemoryStorage
+from automerge.transports import WebSocketClientTransport
+
+
+async def main():
+    """Run the WebSocket client."""
+    # Create a repository with in-memory storage
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        print("Connecting to WebSocket server at ws://localhost:8080...")
+
+        # Connect to the server
+        transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+
+        # Start the connection (this will run until disconnected)
+        conn_task = asyncio.create_task(repo.connect(transport))
+
+        # Give time for handshake
+        await asyncio.sleep(1)
+        print("Connected!")
+
+        # Create a new document
+        handle = await repo.create()
+
+        def init_doc(doc):
+            doc["from"] = "client"
+            doc["clicks"] = 0
+
+        await handle.change(init_doc)
+
+        print(f"\nCreated document: {handle.url}")
+
+        # Make some changes
+        for i in range(5):
+            await asyncio.sleep(2)
+
+            def increment(doc):
+                current = doc["clicks"]
+                new_value = current + 1
+                doc["clicks"] = new_value
+                print(f"Incremented clicks to {new_value}")
+
+            await handle.change(increment)
+
+        print("\nChanges complete. Press Ctrl+C to disconnect.")
+
+        # Wait for user to stop
+        try:
+            await conn_task
+        except KeyboardInterrupt:
+            print("\n\nDisconnecting...")
+            await transport.close()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nExiting...")

--- a/examples/websocket_client.py
+++ b/examples/websocket_client.py
@@ -41,11 +41,9 @@ async def main():
         # Create a new document
         handle = await repo.create()
 
-        def init_doc(doc):
+        with handle.change() as doc:
             doc["from"] = "client"
             doc["clicks"] = 0
-
-        await handle.change(init_doc)
 
         print(f"\nCreated document: {handle.url}")
 
@@ -53,13 +51,13 @@ async def main():
         for i in range(5):
             await asyncio.sleep(2)
 
-            def increment(doc):
-                current = doc["clicks"]
+            # Read current value before change
+            current = handle.doc()["clicks"]
+
+            with handle.change() as doc:
                 new_value = current + 1
                 doc["clicks"] = new_value
                 print(f"Incremented clicks to {new_value}")
-
-            await handle.change(increment)
 
         print("\nChanges complete. Press Ctrl+C to disconnect.")
 

--- a/examples/websocket_server.py
+++ b/examples/websocket_server.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""WebSocket Server Example
+
+This example shows how to run a WebSocket server that shares Automerge
+documents with connected clients.
+
+Usage:
+    python examples/websocket_server.py
+
+The server will start on localhost:8080 and accept connections from clients.
+"""
+
+import asyncio
+from automerge.repo import Repo, InMemoryStorage
+from automerge.transports import WebSocketServer
+
+
+async def main():
+    """Run the WebSocket server."""
+    # Create a repository with in-memory storage
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        print("Starting WebSocket server on ws://localhost:8080")
+
+        # Create an initial document
+        handle = await repo.create()
+
+        def init_doc(doc):
+            doc["message"] = "Hello from server!"
+            doc["counter"] = 0
+
+        await handle.change(init_doc)
+
+        print(f"Created document: {handle.url}")
+        print(f"Document ID: {handle.document_id}")
+
+        # Start the WebSocket server
+        async with WebSocketServer(repo, "localhost", 8080):
+            print("\nServer is running. Press Ctrl+C to stop.")
+            print("Clients can connect to: ws://localhost:8080")
+
+            # Keep the server running
+            try:
+                while True:
+                    await asyncio.sleep(1)
+
+                    # Show active connections
+                    connections = repo._hub.connections()
+                    if connections:
+                        print(
+                            f"\rActive connections: {len(connections)}",
+                            end="",
+                            flush=True,
+                        )
+
+            except KeyboardInterrupt:
+                print("\n\nShutting down server...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/websocket_server.py
+++ b/examples/websocket_server.py
@@ -27,11 +27,9 @@ async def main():
         # Create an initial document
         handle = await repo.create()
 
-        def init_doc(doc):
+        with handle.change() as doc:
             doc["message"] = "Hello from server!"
             doc["counter"] = 0
-
-        await handle.change(init_doc)
 
         print(f"Created document: {handle.url}")
         print(f"Document ID: {handle.document_id}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = ["version"]
+version = "0.2.0.dev1"
 
 # Optional dependencies for additional features
 # Install with: pip install automerge[websocket]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,23 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+# Optional dependencies for additional features
+# Install with: pip install automerge[websocket]
+# Or all extras: pip install automerge[all]
+[project.optional-dependencies]
+websocket = [
+    "websockets>=12.0",
+]
+all = [
+    "websockets>=12.0",
+]
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "automerge._automerge"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+    "pytest-asyncio>=0.23.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.2.0.dev1"
+version = "0.2.0.dev2"
 
 # Optional dependencies for additional features
 # Install with: pip install automerge[websocket]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,26 @@ version = "0.2.0.dev2"
 websocket = [
     "websockets>=12.0",
 ]
+s3 = [
+    "aiobotocore>=2.9.0",
+]
 all = [
     "websockets>=12.0",
+    "aiobotocore>=2.9.0",
 ]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "automerge._automerge"
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (may require external services)",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3.5",
     "pytest-asyncio>=0.23.0",
+    "moto[server]>=5.0.0",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -16,72 +16,73 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "automerge"
-version = "0.5.12"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
+checksum = "b06c470ec20f3ccfbf9103e5539554d5b986852fcefaa9b44298dcca0daf1630"
 dependencies = [
  "cfg-if",
  "flate2",
- "fxhash",
+ "getrandom",
  "hex",
- "im",
+ "hexane",
  "itertools",
  "leb128",
+ "rand",
+ "rustc-hash",
  "serde",
  "sha2",
  "smol_str",
- "thiserror",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "unicode-segmentation",
- "uuid",
 ]
 
 [[package]]
 name = "automerge"
 version = "1.0.0-rc1"
 dependencies = [
- "automerge 0.5.12",
+ "automerge 0.7.2",
  "hex",
  "pyo3",
- "thiserror",
-]
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.0"
+name = "borsh"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "cfg_aliases",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "const-oid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "cpufeatures"
@@ -103,21 +104,21 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -135,25 +136,6 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -181,17 +163,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "im"
-version = "15.1.0"
+name = "hexane"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+checksum = "402a2f365e3200d82b0bb4874f203ad02a480400329990751c6330b1b4007354"
 dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
+ "leb128",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+dependencies = [
  "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -202,21 +189,11 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -267,6 +244,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -354,25 +340,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
+name = "rand"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
+ "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
+name = "rand_chacha"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "serde"
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -422,22 +422,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
 dependencies = [
- "serde",
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -463,7 +454,16 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.57",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -471,6 +471,17 @@ name = "thiserror-impl"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -548,24 +559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
-name = "uuid"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
-dependencies = [
- "getrandom",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,52 +568,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +39,7 @@ dependencies = [
  "rand",
  "rustc-hash",
  "serde",
- "sha2",
+ "sha2 0.11.0-rc.3",
  "smol_str",
  "thiserror 2.0.17",
  "tinyvec",
@@ -45,7 +54,27 @@ dependencies = [
  "automerge 0.7.2",
  "hex",
  "pyo3",
+ "rand",
+ "samod-core",
+ "serde_json",
  "thiserror 1.0.57",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -65,6 +94,22 @@ checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "cfg_aliases",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "sha2 0.10.9",
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cfg-if"
@@ -104,6 +149,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
@@ -113,13 +168,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.11.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.0-rc.5",
 ]
 
 [[package]]
@@ -136,6 +201,16 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -197,6 +272,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,12 +306,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minicbor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -225,6 +363,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -369,10 +516,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "samod-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c15991d17ac520c635dfe2851e8ebe9c4731575f3708e0f80f673147b43ebc"
+dependencies = [
+ "automerge 0.7.2",
+ "base64",
+ "bs58",
+ "hex",
+ "minicbor",
+ "rand",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -405,6 +600,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +631,16 @@ checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-rc.4",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -420,6 +648,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
@@ -489,6 +723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +775,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -559,12 +832,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -552,9 +552,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "samod-core"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c15991d17ac520c635dfe2851e8ebe9c4731575f3708e0f80f673147b43ebc"
+checksum = "3bab909f3bd4ecf787b3221fd4a8b480f385b3e358e84f7ddb379c0d503aa921"
 dependencies = [
  "automerge 0.7.2",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.27.2"
-automerge = "0.5.7"
+automerge = "0.7.2"
 hex = "^0.4.3"
 thiserror = "^1.0.16"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = "0.27.2"
 automerge = "0.7.2"
 hex = "^0.4.3"
 thiserror = "^1.0.16"
-samod-core = { version = "0.5.1"}
+samod-core = { version = "0.7.1"}
 rand = "0.9"
 serde_json = "1.0"
 tracing = "0.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,3 +13,8 @@ pyo3 = "0.27.2"
 automerge = "0.7.2"
 hex = "^0.4.3"
 thiserror = "^1.0.16"
+samod-core = { version = "0.5.1"}
+rand = "0.9"
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -317,11 +317,7 @@ impl Document {
         let after_heads: Vec<ChangeHash> = after_heads.iter().map(|h| h.0).collect();
         Ok(inner
             .doc
-            .diff(
-                &before_heads,
-                &after_heads,
-                am::patches::TextRepresentation::Array,
-            )
+            .diff(&before_heads, &after_heads)
             .into_iter()
             .map(|p| PyPatch(p))
             .collect())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
+    cell::{Cell, RefCell},
     mem::transmute,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use ::automerge::{
@@ -17,9 +18,38 @@ use pyo3::{
     types::{PyBool, PyBytes, PyDateTime, PyTuple},
 };
 
-struct Inner {
-    doc: am::Automerge,
-    tx: Option<am::transaction::Transaction<'static>>,
+mod repo;
+
+/// Reference to an Automerge document - either owned, borrowed, or actor-backed
+enum DocumentRef {
+    /// An owned document
+    Owned(am::Automerge),
+    /// A borrowed document (raw pointer that can be temporarily removed)
+    /// Set to None when the callback completes or needs to be invalidated
+    Borrowed(Cell<Option<*mut am::Automerge>>),
+    /// A reference to a document managed by a DocumentActor
+    /// Each access acquires the mutex lock
+    Actor(Arc<Mutex<samod_core::actors::document::DocumentActor>>),
+}
+
+// SAFETY: DocumentRef is Send + Sync because:
+// - Owned variant contains am::Automerge which is Send + Sync
+// - Borrowed variant is only used within with_document callbacks which execute synchronously
+//   and the pointer is never sent across threads or accessed concurrently
+unsafe impl Send for DocumentRef {}
+unsafe impl Sync for DocumentRef {}
+
+thread_local! {
+    /// Tracks the current document context when inside a with_document() callback.
+    /// Stores (Arc pointer address as identity, document pointer).
+    /// This allows reentrant read access without deadlocking on the mutex.
+    static CURRENT_DOC_CONTEXT: RefCell<Option<(usize, *const am::Automerge)>> =
+        RefCell::new(None);
+}
+
+pub(crate) struct Inner {
+    pub(crate) doc_ref: DocumentRef,
+    pub(crate) tx: Option<am::transaction::Transaction<'static>>,
 }
 
 fn get_heads(heads: Option<Vec<PyChangeHash>>) -> Option<Vec<ChangeHash>> {
@@ -27,8 +57,116 @@ fn get_heads(heads: Option<Vec<PyChangeHash>>) -> Option<Vec<ChangeHash>> {
 }
 
 impl Inner {
-    fn new(doc: am::Automerge) -> Self {
-        Self { doc, tx: None }
+    pub(crate) fn new(doc: am::Automerge) -> Self {
+        Self {
+            doc_ref: DocumentRef::Owned(doc),
+            tx: None,
+        }
+    }
+
+    pub(crate) fn new_borrowed(doc_ptr: *mut am::Automerge) -> Self {
+        Self {
+            doc_ref: DocumentRef::Borrowed(Cell::new(Some(doc_ptr))),
+            tx: None,
+        }
+    }
+
+    /// Execute a callback with an immutable reference to the document
+    ///
+    /// For Owned and Borrowed documents, provides direct reference.
+    /// For Actor-backed documents, acquires mutex lock before calling callback.
+    ///
+    /// Returns error if:
+    /// - Called on a borrowed document that has been invalidated
+    /// - Called while a transaction is active (transaction has exclusive access)
+    fn with_doc<F, R>(&self, f: F) -> PyResult<R>
+    where
+        F: FnOnce(&am::Automerge) -> R,
+    {
+        if self.tx.is_some() {
+            return Err(PyException::new_err(
+                "Cannot access document while transaction is active",
+            ));
+        }
+
+        match &self.doc_ref {
+            DocumentRef::Owned(doc) => Ok(f(doc)),
+            DocumentRef::Borrowed(cell) => {
+                let ptr = cell.get().ok_or_else(|| {
+                    PyException::new_err(
+                        "Document cannot be accessed: either used after with_document callback completed, or invalidated"
+                    )
+                })?;
+                // SAFETY: The pointer is valid because:
+                // 1. It was created from a valid reference
+                // 2. We're within the callback scope (otherwise ptr would be None)
+                // 3. No transaction is active (checked above)
+                Ok(f(unsafe { &*ptr }))
+            }
+            DocumentRef::Actor(arc_mutex) => {
+                // Get the identity of this actor (Arc pointer address)
+                let arc_id = Arc::as_ptr(arc_mutex) as usize;
+
+                // Check if we're currently inside a callback for THIS actor
+                let context = CURRENT_DOC_CONTEXT.with(|ctx| *ctx.borrow());
+
+                if let Some((ctx_arc_id, doc_ptr)) = context {
+                    if ctx_arc_id == arc_id {
+                        // We're in a callback for this same actor!
+                        // Use the existing document reference instead of locking
+                        // SAFETY: The pointer is valid because:
+                        // 1. We're on the same thread (thread-local storage)
+                        // 2. The callback is still executing (context would be None otherwise)
+                        // 3. Python GIL ensures single-threaded execution
+                        // 4. The document reference outlives this operation
+                        return Ok(f(unsafe { &*doc_ptr }));
+                    }
+                }
+
+                // Not in a callback, or different actor: use normal mutex path
+                let actor = arc_mutex.lock().unwrap();
+                let doc = actor.document();
+                Ok(f(doc))
+            }
+        }
+    }
+
+    /// Get a mutable reference to the document
+    fn doc_mut(&mut self) -> PyResult<&mut am::Automerge> {
+        if self.tx.is_some() {
+            return Err(PyException::new_err(
+                "cannot mutate docuemnt with an active transaction",
+            ));
+        }
+        match &mut self.doc_ref {
+            DocumentRef::Owned(doc) => Ok(doc),
+            DocumentRef::Borrowed(cell) => {
+                let ptr = cell.get().ok_or_else(|| {
+                    PyException::new_err(
+                        "Document cannot be accessed: either used after with_document callback completed, or invalidated"
+                    )
+                })?;
+                // SAFETY: We're about to create a transaction which will have exclusive access
+                Ok(unsafe { &mut *ptr })
+            },
+            DocumentRef::Actor(_) => {
+                Err(PyException::new_err(
+                    "Cannot mutate read-only document from DocHandle.doc(). Use DocHandle.change() instead."
+                ))
+            }
+        }
+    }
+
+    /// Invalidate a borrowed document (no-op for owned documents)
+    pub(crate) fn invalidate(&self) {
+        if let DocumentRef::Borrowed(ref cell) = self.doc_ref {
+            cell.set(None);
+        }
+    }
+
+    /// Check if this is a borrowed document
+    fn is_borrowed(&self) -> bool {
+        matches!(self.doc_ref, DocumentRef::Borrowed(_))
     }
 
     // Read methods go on Inner as they're callable from either Transaction or Document.
@@ -36,7 +174,7 @@ impl Inner {
         if let Some(tx) = self.tx.as_ref() {
             tx.object_type(obj_id.0)
         } else {
-            self.doc.object_type(obj_id.0)
+            self.with_doc(|doc| doc.object_type(obj_id.0))?
         }
         .map_err(|e| PyException::new_err(e.to_string()))
         .map(PyObjType::from_objtype)
@@ -48,34 +186,41 @@ impl Inner {
         prop: PyProp,
         heads: Option<Vec<PyChangeHash>>,
     ) -> PyResult<Option<(PyValue<'py>, PyObjId)>> {
-        let res = if let Some(tx) = self.tx.as_ref() {
-            match get_heads(heads) {
+        if let Some(tx) = self.tx.as_ref() {
+            let res = match get_heads(heads) {
                 Some(heads) => tx.get_at(obj_id.0, prop.0, &heads),
                 None => tx.get(obj_id.0, prop.0),
             }
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+            Ok(res.map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id))))
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.get_at(obj_id.0, prop.0, &heads),
-                None => self.doc.get(obj_id.0, prop.0),
-            }
+            self.with_doc(|doc| {
+                let res = match get_heads(heads) {
+                    Some(heads) => doc.get_at(obj_id.0, prop.0, &heads),
+                    None => doc.get(obj_id.0, prop.0),
+                }
+                .map_err(|e| PyException::new_err(e.to_string()))?;
+                Ok(res.map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id))))
+            })?
         }
-        .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(res.map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id))))
     }
 
     fn keys(&self, obj_id: PyObjId, heads: Option<Vec<PyChangeHash>>) -> PyResult<Vec<String>> {
-        let res = if let Some(tx) = self.tx.as_ref() {
-            match get_heads(heads) {
+        if let Some(tx) = self.tx.as_ref() {
+            let res = match get_heads(heads) {
                 Some(heads) => tx.keys_at(obj_id.0, &heads),
                 None => tx.keys(obj_id.0),
-            }
+            };
+            Ok(res.collect())
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.keys_at(obj_id.0, &heads),
-                None => self.doc.keys(obj_id.0),
-            }
-        };
-        Ok(res.collect())
+            self.with_doc(|doc| {
+                let res = match get_heads(heads) {
+                    Some(heads) => doc.keys_at(obj_id.0, &heads),
+                    None => doc.keys(obj_id.0),
+                };
+                res.collect()
+            })
+        }
     }
 
     fn values<'py>(
@@ -83,44 +228,47 @@ impl Inner {
         obj_id: PyObjId,
         heads: Option<Vec<PyChangeHash>>,
     ) -> PyResult<Vec<(PyValue<'py>, PyObjId)>> {
-        let res = if let Some(tx) = self.tx.as_ref() {
-            match get_heads(heads) {
+        if let Some(tx) = self.tx.as_ref() {
+            let res = match get_heads(heads) {
                 Some(heads) => tx.values_at(obj_id.0, &heads),
                 None => tx.values(obj_id.0),
-            }
+            };
+            Ok(res
+                .map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id)))
+                .collect())
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.values_at(obj_id.0, &heads),
-                None => self.doc.values(obj_id.0),
-            }
+            self.with_doc(|doc| {
+                let res = match get_heads(heads) {
+                    Some(heads) => doc.values_at(obj_id.0, &heads),
+                    None => doc.values(obj_id.0),
+                };
+                res.map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id)))
+                    .collect()
+            })
         }
-        .map(|(v, id)| (PyValue(v.into_owned()), PyObjId(id)));
-        Ok(res.collect())
     }
 
-    fn get_heads(&self) -> Vec<PyChangeHash> {
-        if let Some(tx) = self.tx.as_ref() {
+    fn get_heads(&self) -> PyResult<Vec<PyChangeHash>> {
+        let heads = if let Some(tx) = self.tx.as_ref() {
             tx.get_heads()
         } else {
-            self.doc.get_heads()
-        }
-        .into_iter()
-        .map(|c| PyChangeHash(c))
-        .collect()
+            self.with_doc(|doc| doc.get_heads())?
+        };
+        Ok(heads.into_iter().map(|c| PyChangeHash(c)).collect())
     }
 
-    fn length(&self, obj_id: PyObjId, heads: Option<Vec<PyChangeHash>>) -> usize {
-        if let Some(tx) = self.tx.as_ref() {
+    fn length(&self, obj_id: PyObjId, heads: Option<Vec<PyChangeHash>>) -> PyResult<usize> {
+        Ok(if let Some(tx) = self.tx.as_ref() {
             match get_heads(heads) {
                 Some(heads) => tx.length_at(obj_id.0, &heads),
                 None => tx.length(obj_id.0),
             }
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.length_at(obj_id.0, &heads),
-                None => self.doc.length(obj_id.0),
-            }
-        }
+            self.with_doc(|doc| match get_heads(heads) {
+                Some(heads) => doc.length_at(obj_id.0, &heads),
+                None => doc.length(obj_id.0),
+            })?
+        })
     }
 
     fn text(&self, obj_id: PyObjId, heads: Option<Vec<PyChangeHash>>) -> PyResult<String> {
@@ -130,10 +278,10 @@ impl Inner {
                 None => tx.text(obj_id.0),
             }
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.text_at(obj_id.0, &heads),
-                None => self.doc.text(obj_id.0),
-            }
+            self.with_doc(|doc| match get_heads(heads) {
+                Some(heads) => doc.text_at(obj_id.0, &heads),
+                None => doc.text(obj_id.0),
+            })?
         }
         .map_err(|e| PyException::new_err(e.to_string()))
     }
@@ -145,10 +293,10 @@ impl Inner {
                 None => tx.marks(obj_id.0),
             }
         } else {
-            match get_heads(heads) {
-                Some(heads) => self.doc.marks_at(obj_id.0, &heads),
-                None => self.doc.marks(obj_id.0),
-            }
+            self.with_doc(|doc| match get_heads(heads) {
+                Some(heads) => doc.marks_at(obj_id.0, &heads),
+                None => doc.marks(obj_id.0),
+            })?
         }
         .map_err(|e| PyException::new_err(e.to_string()))?;
         Ok(res
@@ -163,9 +311,61 @@ impl Inner {
     }
 }
 
-#[pyclass]
-struct Document {
+// A unified Automerge document that can be owned, borrowed, or part of a DocumentActor.
+//
+// Owned documents are created with `Document::new()` and own their Automerge document.
+// Borrowed documents are created within `with_document` callbacks and wrap a raw pointer
+// to a document that exists elsewhere. The document actor version is created
+// with Document::new_from_actor
+#[pyclass(name = "Document")]
+pub(crate) struct Document {
     inner: Arc<RwLock<Inner>>,
+}
+
+// SAFETY: Document is Send + Sync because it uses Arc<RwLock<Inner>>
+// which properly synchronizes access across threads
+unsafe impl Send for Document {}
+unsafe impl Sync for Document {}
+
+impl Document {
+    /// Create a new borrowed Document from a mutable reference
+    ///
+    /// SAFETY: The caller must ensure that:
+    /// 1. The document reference remains valid for the lifetime of this Document
+    /// 2. invalidate() is called before the document reference becomes invalid
+    /// 3. Only one borrowed Document exists for a given document at a time
+    pub(crate) unsafe fn new_borrowed(doc: &mut am::Automerge) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Inner::new_borrowed(doc as *mut am::Automerge))),
+        }
+    }
+
+    /// Invalidate a borrowed document (no-op for owned documents)
+    ///
+    /// This should be called after the with_document callback completes to ensure
+    /// that any further attempts to use a borrowed document will panic instead of causing UB.
+    pub(crate) fn invalidate(&self) {
+        let inner = self.inner.read().expect("Failed to acquire read lock");
+        inner.invalidate();
+    }
+
+    /// Create a new Document backed by a DocumentActor
+    ///
+    /// The returned document is read-only and acquires the actor's mutex on each access.
+    /// This allows direct property access without callbacks, but with the trade-off of
+    /// mutex acquisition overhead per operation.
+    ///
+    /// Transactions cannot be created on actor-backed documents.
+    pub(crate) fn new_from_actor(
+        actor: Arc<Mutex<samod_core::actors::document::DocumentActor>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Inner {
+                doc_ref: DocumentRef::Actor(actor),
+                tx: None,
+            })),
+        }
+    }
 }
 
 #[pymethods]
@@ -187,173 +387,58 @@ impl Document {
             .inner
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot get actor id with an active transaction",
-            ));
-        }
-
-        Ok(PyBytes::new(py, inner.doc.get_actor().to_bytes()))
+        inner.with_doc(|doc| PyBytes::new(py, doc.get_actor().to_bytes()))
     }
 
     fn set_actor(&mut self, actor_id: &[u8]) -> PyResult<()> {
-        let mut inner = self
+        let inner = self
             .inner
-            .write()
-            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
-        if inner.tx.is_some() {
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        // Check if this is a borrowed document
+        if inner.is_borrowed() {
             return Err(PyException::new_err(
-                "cannot set actor with an active transaction",
+                "cannot set actor id on a borrowed document",
             ));
         }
 
-        inner.doc.set_actor(ActorId::from(actor_id));
-        Ok(())
-    }
+        // Drop the read lock before acquiring write lock
+        drop(inner);
 
-    fn transaction(&self) -> PyResult<Transaction> {
         let mut inner = self
             .inner
             .write()
             .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+
+        // Get mutable reference to the document
+        let doc = inner.doc_mut()?;
+        doc.set_actor(ActorId::from(actor_id));
+        Ok(())
+    }
+
+    fn transaction(&mut self) -> PyResult<Transaction> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+
         if inner.tx.is_some() {
             return Err(PyException::new_err("transaction already active"));
         }
 
-        // Here we're transmuting the lifetime of the transaction to `static`, which is okay
+        // Get mutable reference to the document and create transaction
+        let doc = inner.doc_mut()?;
+
+        // SAFETY: We're transmuting the lifetime of the transaction to `static`, which is okay
         // because we are then storing the transaction in `Inner` which means the document will
         // live as long as the transaction.
-        let tx = unsafe { transmute(inner.doc.transaction()) };
+        let tx = unsafe { transmute(doc.transaction()) };
         inner.tx = Some(tx);
+
         Ok(Transaction {
             inner: Arc::clone(&self.inner),
         })
-    }
-
-    fn save<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot save with an active transaction",
-            ));
-        }
-
-        Ok(PyBytes::new(py, &inner.doc.save()))
-    }
-
-    #[staticmethod]
-    fn load(bytes: &[u8]) -> PyResult<Self> {
-        let doc = am::Automerge::load(bytes).map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(Self {
-            inner: Arc::new(RwLock::new(Inner::new(doc))),
-        })
-    }
-
-    #[pyo3(signature=(heads=None))]
-    fn fork(&self, heads: Option<Vec<PyChangeHash>>) -> PyResult<Document> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot fork with an active transaction",
-            ));
-        }
-        let new_doc = match get_heads(heads) {
-            Some(heads) => inner.doc.fork_at(&heads),
-            None => Ok(inner.doc.fork()),
-        }
-        .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(Document {
-            inner: Arc::new(RwLock::new(Inner::new(new_doc))),
-        })
-    }
-
-    fn merge(&mut self, other: &Document) -> PyResult<Vec<PyChangeHash>> {
-        let mut inner = self
-            .inner
-            .write()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot merge with an active transaction",
-            ));
-        }
-        let mut other_inner = other
-            .inner
-            .write()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if other_inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot merge with an active transaction",
-            ));
-        }
-        inner
-            .doc
-            .merge(&mut other_inner.doc)
-            .map(|change_hashes| change_hashes.into_iter().map(|h| PyChangeHash(h)).collect())
-            .map_err(|e| PyException::new_err(e.to_string()))
-    }
-
-    fn diff(
-        &self,
-        before_heads: Vec<PyChangeHash>,
-        after_heads: Vec<PyChangeHash>,
-    ) -> PyResult<Vec<PyPatch>> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot diff with an active transaction",
-            ));
-        }
-        let before_heads: Vec<ChangeHash> = before_heads.iter().map(|h| h.0).collect();
-        let after_heads: Vec<ChangeHash> = after_heads.iter().map(|h| h.0).collect();
-        Ok(inner
-            .doc
-            .diff(&before_heads, &after_heads)
-            .into_iter()
-            .map(|p| PyPatch(p))
-            .collect())
-    }
-
-    fn generate_sync_message(&self, state: &mut PySyncState) -> PyResult<Option<PyMessage>> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot sync with an active transaction",
-            ));
-        }
-        Ok(inner.doc.generate_sync_message(&mut state.0).map(PyMessage))
-    }
-
-    fn receive_sync_message(
-        &mut self,
-        state: &mut PySyncState,
-        message: &mut PyMessage,
-    ) -> PyResult<()> {
-        let mut inner = self
-            .inner
-            .write()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot sync with an active transaction",
-            ));
-        }
-        inner
-            .doc
-            .receive_sync_message(&mut state.0, message.0.clone())
-            .map_err(|e| PyException::new_err(e.to_string()))
     }
 
     fn get_heads(&self) -> PyResult<Vec<PyChangeHash>> {
@@ -361,18 +446,7 @@ impl Document {
             .inner
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(inner.get_heads())
-    }
-
-    fn get_last_local_change(&self) -> PyResult<Option<PyChange>> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(inner
-            .doc
-            .get_last_local_change()
-            .map(|c| PyChange(c.to_owned())))
+        inner.get_heads()
     }
 
     fn object_type(&self, obj_id: PyObjId) -> PyResult<PyObjType> {
@@ -381,26 +455,6 @@ impl Document {
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
         inner.object_type(obj_id)
-    }
-
-    fn get_changes(&self, have_deps: Vec<PyChangeHash>) -> PyResult<Vec<PyChange>> {
-        let inner = self
-            .inner
-            .read()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        if inner.tx.is_some() {
-            return Err(PyException::new_err(
-                "cannot get changes with an active transaction",
-            ));
-        }
-
-        let changes: Vec<ChangeHash> = have_deps.iter().map(|h| h.0).collect();
-        Ok(inner
-            .doc
-            .get_changes(&changes)
-            .into_iter()
-            .map(|c| PyChange(c.to_owned()))
-            .collect())
     }
 
     #[pyo3(signature=(obj_id, prop, heads=None))]
@@ -445,7 +499,7 @@ impl Document {
             .inner
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(inner.length(obj_id, heads))
+        inner.length(obj_id, heads)
     }
 
     #[pyo3(signature=(obj_id, heads=None))]
@@ -464,6 +518,173 @@ impl Document {
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
         inner.marks(obj_id, heads)
+    }
+
+    fn fork(&self) -> PyResult<Self> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        inner.with_doc(|doc| Document {
+            inner: Arc::new(RwLock::new(Inner::new(doc.fork()))),
+        })
+    }
+
+    fn fork_at(&self, heads: Vec<PyChangeHash>) -> PyResult<Self> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let heads: Vec<_> = heads.iter().map(|h| h.0).collect();
+        inner.with_doc(|doc| {
+            doc.fork_at(&heads)
+                .map(|forked| Document {
+                    inner: Arc::new(RwLock::new(Inner::new(forked))),
+                })
+                .map_err(|e| PyException::new_err(e.to_string()))
+        })?
+    }
+
+    fn merge(&mut self, other: &Document) -> PyResult<Vec<PyChangeHash>> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+
+        if inner.tx.is_some() {
+            return Err(PyException::new_err(
+                "cannot merge with an active transaction",
+            ));
+        }
+
+        let mut other_inner = other
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        // Get mutable references to both documents for merging
+        let doc = match &mut inner.doc_ref {
+            DocumentRef::Owned(ref mut d) => d,
+            DocumentRef::Borrowed(ref cell) => {
+                let ptr = cell.get().ok_or_else(|| {
+                    PyException::new_err("Document cannot be accessed: invalidated")
+                })?;
+                unsafe { &mut *ptr }
+            }
+            DocumentRef::Actor(_) => {
+                return Err(PyException::new_err(
+                    "Cannot merge actor-backed document. Use DocHandle.change() for modifications.",
+                ));
+            }
+        };
+
+        let other_doc = match &mut other_inner.doc_ref {
+            DocumentRef::Owned(ref mut d) => d,
+            DocumentRef::Borrowed(ref cell) => {
+                let ptr = cell.get().ok_or_else(|| {
+                    PyException::new_err("Document cannot be accessed: invalidated")
+                })?;
+                unsafe { &mut *ptr }
+            }
+            DocumentRef::Actor(_) => {
+                return Err(PyException::new_err(
+                    "Cannot merge actor-backed document. Use DocHandle.change() for modifications.",
+                ));
+            }
+        };
+
+        let heads = doc
+            .merge(other_doc)
+            .map_err(|e| PyException::new_err(e.to_string()))?
+            .into_iter()
+            .map(PyChangeHash)
+            .collect();
+        Ok(heads)
+    }
+
+    fn save(&self) -> PyResult<Vec<u8>> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        inner.with_doc(|doc| doc.save())
+    }
+
+    #[staticmethod]
+    fn load(data: &[u8]) -> PyResult<Self> {
+        let doc = am::Automerge::load(data).map_err(|e| PyException::new_err(e.to_string()))?;
+        Ok(Document {
+            inner: Arc::new(RwLock::new(Inner::new(doc))),
+        })
+    }
+
+    fn generate_sync_message(&self, sync_state: &mut PySyncState) -> PyResult<Option<PyMessage>> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        inner.with_doc(|doc| doc.generate_sync_message(&mut sync_state.0).map(PyMessage))
+    }
+
+    fn receive_sync_message(
+        &mut self,
+        sync_state: &mut PySyncState,
+        message: &PyMessage,
+    ) -> PyResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+
+        if inner.tx.is_some() {
+            return Err(PyException::new_err(
+                "cannot receive sync message with an active transaction",
+            ));
+        }
+
+        let doc = inner.doc_mut()?;
+        doc.receive_sync_message(&mut sync_state.0, message.0.clone())
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    fn get_changes(&self, heads: Vec<PyChangeHash>) -> PyResult<Vec<PyChange>> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let heads: Vec<_> = heads.iter().map(|h| h.0).collect();
+        inner.with_doc(|doc| {
+            doc.get_changes(&heads)
+                .into_iter()
+                .map(|c| PyChange(c.clone()))
+                .collect()
+        })
+    }
+
+    fn get_last_local_change(&self) -> PyResult<Option<PyChange>> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        inner.with_doc(|doc| doc.get_last_local_change().map(|c| PyChange(c.clone())))
+    }
+
+    fn diff(&self, before: Vec<PyChangeHash>, after: Vec<PyChangeHash>) -> PyResult<Vec<PyPatch>> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+
+        let before: Vec<_> = before.iter().map(|h| h.0).collect();
+        let after: Vec<_> = after.iter().map(|h| h.0).collect();
+        inner.with_doc(|doc| doc.diff(&before, &after).into_iter().map(PyPatch).collect())
     }
 }
 
@@ -506,7 +727,7 @@ impl Transaction {
             .inner
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(inner.get_heads())
+        inner.get_heads()
     }
 
     fn object_type(&self, obj_id: PyObjId) -> PyResult<PyObjType> {
@@ -559,7 +780,7 @@ impl Transaction {
             .inner
             .read()
             .map_err(|e| PyException::new_err(e.to_string()))?;
-        Ok(inner.length(obj_id, heads))
+        inner.length(obj_id, heads)
     }
 
     #[pyo3(signature=(obj_id, heads=None))]
@@ -800,7 +1021,7 @@ fn random_actor_id<'py>(py: Python<'py>) -> Bound<'py, PyBytes> {
 /// A Python module implemented in Rust.
 #[pymodule]
 fn _automerge(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Classes
+    // Document classes
     m.add_class::<Document>()?;
     m.add_class::<Transaction>()?;
     m.add_class::<PySyncState>()?;
@@ -816,6 +1037,36 @@ fn _automerge(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Functions
     m.add_function(wrap_pyfunction!(random_actor_id, m)?)?;
+    m.add_function(wrap_pyfunction!(enable_tracing, m)?)?;
+
+    // Repo types
+    repo::register_types(m)?;
+
+    Ok(())
+}
+
+/// Enable tracing output for debugging samod-core internals
+///
+/// This initializes the tracing subscriber to output logs to stderr.
+/// Call this before creating repos to see internal samod-core logs.
+///
+/// Args:
+///     level: Optional log level filter (e.g., "trace", "debug", "info"). Defaults to "debug".
+#[pyfunction]
+fn enable_tracing(level: Option<String>) -> PyResult<()> {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let filter = match level {
+        Some(l) => EnvFilter::new(l),
+        None => EnvFilter::new("info"),
+    };
+
+    fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .with_line_number(true)
+        .try_init()
+        .map_err(|e| PyException::new_err(format!("Failed to initialize tracing: {}", e)))?;
 
     Ok(())
 }
@@ -862,7 +1113,7 @@ impl<'py> IntoPyObject<'py> for PyObjId {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PyChangeHash(am::ChangeHash);
 
 impl<'a, 'py> FromPyObject<'a, 'py> for PyChangeHash {
@@ -1111,7 +1362,7 @@ impl PyChange {
 }
 
 #[pyclass(name = "Patch")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PyPatch(am::Patch);
 
 #[pymethods]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,10 +40,11 @@ unsafe impl Send for DocumentRef {}
 unsafe impl Sync for DocumentRef {}
 
 thread_local! {
-    /// Tracks the current document context when inside a with_document() callback.
-    /// Stores (Arc pointer address as identity, document pointer).
-    /// This allows reentrant read access without deadlocking on the mutex.
-    static CURRENT_DOC_CONTEXT: RefCell<Option<(usize, *const am::Automerge)>> =
+    /// Tracks the current document context when inside a change() context
+    /// manager. Stores the Arc pointer address of the document actor as
+    /// identity This allows us to detect re-entrant calls to DocHandle.change()
+    /// and throw an error to avoid deadlocks
+    static CURRENT_DOC_CONTEXT: RefCell<Option<usize>> =
         RefCell::new(None);
 }
 
@@ -107,23 +108,21 @@ impl Inner {
                 // Get the identity of this actor (Arc pointer address)
                 let arc_id = Arc::as_ptr(arc_mutex) as usize;
 
-                // Check if we're currently inside a callback for THIS actor
+                // Check if we're currently inside a change block for THIS actor
                 let context = CURRENT_DOC_CONTEXT.with(|ctx| *ctx.borrow());
 
-                if let Some((ctx_arc_id, doc_ptr)) = context {
+                if let Some(ctx_arc_id) = context {
                     if ctx_arc_id == arc_id {
-                        // We're in a callback for this same actor!
-                        // Use the existing document reference instead of locking
-                        // SAFETY: The pointer is valid because:
-                        // 1. We're on the same thread (thread-local storage)
-                        // 2. The callback is still executing (context would be None otherwise)
-                        // 3. Python GIL ensures single-threaded execution
-                        // 4. The document reference outlives this operation
-                        return Ok(f(unsafe { &*doc_ptr }));
+                        // We're inside a change() block for this actor.
+                        // Reject the doc() call - user should use the proxy returned by change().
+                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                            "Cannot call doc() inside a change() block. \
+                             Use the proxy returned by change() instead.",
+                        ));
                     }
                 }
 
-                // Not in a callback, or different actor: use normal mutex path
+                // Not in a change block, or different actor: use normal mutex path
                 let actor = arc_mutex.lock().unwrap();
                 let doc = actor.document();
                 Ok(f(doc))
@@ -718,6 +717,30 @@ impl Transaction {
             } else {
                 tx.commit();
             }
+        }
+        Ok(())
+    }
+
+    /// Commit the transaction, applying all changes to the document.
+    fn commit(&self) -> PyResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+        if let Some(tx) = inner.tx.take() {
+            tx.commit();
+        }
+        Ok(())
+    }
+
+    /// Rollback the transaction, discarding all changes.
+    fn rollback(&self) -> PyResult<()> {
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|e| PyException::new_err(format!("error getting write lock: {}", e)))?;
+        if let Some(tx) = inner.tx.take() {
+            tx.rollback();
         }
         Ok(())
     }

--- a/rust/src/repo/commands.rs
+++ b/rust/src/repo/commands.rs
@@ -1,0 +1,276 @@
+use pyo3::prelude::*;
+
+use super::hub_events::PyHubEvent;
+use super::types::{PyConnectionId, PyDocumentActorId, PyDocumentId};
+
+/// Wrapper for samod_core::CommandId
+///
+/// Represents a unique identifier for a command dispatched to the hub.
+#[pyclass(name = "CommandId")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PyCommandId(pub(crate) samod_core::CommandId);
+
+#[pymethods]
+impl PyCommandId {
+    /// Create a CommandId from a u32
+    #[staticmethod]
+    fn from_u32(id: u32) -> Self {
+        PyCommandId(samod_core::CommandId::from(id))
+    }
+
+    /// Get the u32 representation of this CommandId
+    fn to_u32(&self) -> u32 {
+        self.0.into()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("CommandId({})", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        u32::from(self.0) as u64
+    }
+}
+
+/// Wrapper for samod_core::actors::hub::DispatchedCommand
+///
+/// A command that has been prepared for execution with a unique identifier.
+#[pyclass(name = "DispatchedCommand")]
+pub struct PyDispatchedCommand {
+    command_id: samod_core::actors::hub::CommandId,
+    event: samod_core::actors::hub::HubEvent,
+}
+
+#[pymethods]
+impl PyDispatchedCommand {
+    /// Get the command ID for tracking completion
+    #[getter]
+    fn command_id(&self) -> PyCommandId {
+        PyCommandId(self.command_id)
+    }
+
+    /// Get the event to be processed
+    #[getter]
+    fn event(&self) -> PyHubEvent {
+        PyHubEvent {
+            inner: self.event.clone(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("DispatchedCommand(command_id={})", self.command_id)
+    }
+}
+
+impl PyDispatchedCommand {
+    pub(crate) fn new(
+        command_id: samod_core::actors::hub::CommandId,
+        event: samod_core::actors::hub::HubEvent,
+    ) -> Self {
+        PyDispatchedCommand { command_id, event }
+    }
+}
+
+// ===== Command Result =====
+
+/// CreateConnection command result - new connection was created
+#[pyclass(name = "CommandResultCreateConnection")]
+#[derive(Clone)]
+pub struct PyCommandResultCreateConnection {
+    #[pyo3(get)]
+    connection_id: PyConnectionId,
+}
+
+#[pymethods]
+impl PyCommandResultCreateConnection {
+    #[new]
+    fn new(connection_id: PyConnectionId) -> Self {
+        PyCommandResultCreateConnection { connection_id }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CommandResultCreateConnection(connection_id={:?})",
+            self.connection_id.0
+        )
+    }
+}
+
+/// DisconnectConnection command result - connection was disconnected
+#[pyclass(name = "CommandResultDisconnectConnection")]
+#[derive(Clone)]
+pub struct PyCommandResultDisconnectConnection;
+
+#[pymethods]
+impl PyCommandResultDisconnectConnection {
+    #[new]
+    fn new() -> Self {
+        PyCommandResultDisconnectConnection
+    }
+
+    fn __repr__(&self) -> String {
+        "CommandResultDisconnectConnection".to_string()
+    }
+}
+
+/// Receive command result - message was received on a connection
+#[pyclass(name = "CommandResultReceive")]
+#[derive(Clone)]
+pub struct PyCommandResultReceive {
+    #[pyo3(get)]
+    connection_id: PyConnectionId,
+    #[pyo3(get)]
+    error: Option<String>,
+}
+
+#[pymethods]
+impl PyCommandResultReceive {
+    #[new]
+    fn new(connection_id: PyConnectionId, error: Option<String>) -> Self {
+        PyCommandResultReceive {
+            connection_id,
+            error,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CommandResultReceive(connection_id={:?}, error={:?})",
+            self.connection_id.0, self.error
+        )
+    }
+}
+
+/// ActorReady command result - actor is ready to process messages
+#[pyclass(name = "CommandResultActorReady")]
+#[derive(Clone)]
+pub struct PyCommandResultActorReady;
+
+#[pymethods]
+impl PyCommandResultActorReady {
+    #[new]
+    fn new() -> Self {
+        PyCommandResultActorReady
+    }
+
+    fn __repr__(&self) -> String {
+        "CommandResultActorReady".to_string()
+    }
+}
+
+/// CreateDocument command result - new document was created
+#[pyclass(name = "CommandResultCreateDocument")]
+#[derive(Clone)]
+pub struct PyCommandResultCreateDocument {
+    #[pyo3(get)]
+    actor_id: PyDocumentActorId,
+    #[pyo3(get)]
+    document_id: PyDocumentId,
+}
+
+#[pymethods]
+impl PyCommandResultCreateDocument {
+    #[new]
+    fn new(actor_id: PyDocumentActorId, document_id: PyDocumentId) -> Self {
+        PyCommandResultCreateDocument {
+            actor_id,
+            document_id,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CommandResultCreateDocument(actor_id={}, document_id={})",
+            self.actor_id.0, self.document_id.0
+        )
+    }
+}
+
+/// FindDocument command result - document was found (or not)
+#[pyclass(name = "CommandResultFindDocument")]
+#[derive(Clone)]
+pub struct PyCommandResultFindDocument {
+    #[pyo3(get)]
+    actor_id: PyDocumentActorId,
+    #[pyo3(get)]
+    found: bool,
+}
+
+#[pymethods]
+impl PyCommandResultFindDocument {
+    #[new]
+    fn new(actor_id: PyDocumentActorId, found: bool) -> Self {
+        PyCommandResultFindDocument { actor_id, found }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CommandResultFindDocument(actor_id={}, found={})",
+            self.actor_id.0, self.found
+        )
+    }
+}
+
+// Helper function to convert Rust CommandResult to appropriate Python subclass
+pub(crate) fn command_result_to_py(
+    py: Python<'_>,
+    result: &samod_core::actors::hub::CommandResult,
+) -> PyResult<PyObject> {
+    match result {
+        samod_core::actors::hub::CommandResult::CreateConnection { connection_id } => Py::new(
+            py,
+            PyCommandResultCreateConnection {
+                connection_id: PyConnectionId(*connection_id),
+            },
+        )
+        .map(|obj| obj.into()),
+        samod_core::actors::hub::CommandResult::DisconnectConnection => {
+            Py::new(py, PyCommandResultDisconnectConnection).map(|obj| obj.into())
+        }
+        samod_core::actors::hub::CommandResult::Receive {
+            connection_id,
+            error,
+        } => Py::new(
+            py,
+            PyCommandResultReceive {
+                connection_id: PyConnectionId(*connection_id),
+                error: error.clone(),
+            },
+        )
+        .map(|obj| obj.into()),
+        samod_core::actors::hub::CommandResult::ActorReady => {
+            Py::new(py, PyCommandResultActorReady).map(|obj| obj.into())
+        }
+        samod_core::actors::hub::CommandResult::CreateDocument {
+            actor_id,
+            document_id,
+        } => Py::new(
+            py,
+            PyCommandResultCreateDocument {
+                actor_id: PyDocumentActorId(*actor_id),
+                document_id: PyDocumentId(document_id.clone()),
+            },
+        )
+        .map(|obj| obj.into()),
+        samod_core::actors::hub::CommandResult::FindDocument { actor_id, found } => Py::new(
+            py,
+            PyCommandResultFindDocument {
+                actor_id: PyDocumentActorId(*actor_id),
+                found: *found,
+            },
+        )
+        .map(|obj| obj.into()),
+    }
+}

--- a/rust/src/repo/connection.rs
+++ b/rust/src/repo/connection.rs
@@ -1,0 +1,238 @@
+//! Connection info types
+//!
+//! This module contains types for representing connection information
+//! such as connection state, peer document synchronization state, etc.
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::collections::HashMap;
+
+use super::types::{PyConnectionId, PyPeerId, PyDocumentId};
+
+// ===== Connection State =====
+
+/// Base class for connection state
+#[pyclass(name = "ConnectionState", subclass)]
+#[derive(Clone)]
+pub struct PyConnectionState;
+
+#[pymethods]
+impl PyConnectionState {
+    fn __repr__(&self) -> String {
+        "ConnectionState".to_string()
+    }
+}
+
+/// Connection state: Handshaking - still exchanging peer IDs
+#[pyclass(name = "ConnectionStateHandshaking", extends = PyConnectionState)]
+#[derive(Clone)]
+pub struct PyConnectionStateHandshaking;
+
+#[pymethods]
+impl PyConnectionStateHandshaking {
+    #[new]
+    fn new() -> (Self, PyConnectionState) {
+        (PyConnectionStateHandshaking, PyConnectionState)
+    }
+
+    fn __repr__(&self) -> String {
+        "ConnectionStateHandshaking()".to_string()
+    }
+}
+
+/// Connection state: Connected - connected with a peer and synchronizing documents
+#[pyclass(name = "ConnectionStateConnected", extends = PyConnectionState)]
+#[derive(Clone)]
+pub struct PyConnectionStateConnected {
+    /// The peer ID of the connected peer
+    #[pyo3(get)]
+    pub their_peer_id: PyPeerId,
+}
+
+#[pymethods]
+impl PyConnectionStateConnected {
+    #[new]
+    fn new(their_peer_id: PyPeerId) -> (Self, PyConnectionState) {
+        (PyConnectionStateConnected { their_peer_id }, PyConnectionState)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("ConnectionStateConnected(their_peer_id={})", self.their_peer_id.0)
+    }
+}
+
+/// Helper enum for internal use
+pub(crate) enum ConnectionStateVariant {
+    Handshaking(Py<PyConnectionStateHandshaking>),
+    Connected(Py<PyConnectionStateConnected>),
+}
+
+impl Clone for ConnectionStateVariant {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| match self {
+            ConnectionStateVariant::Handshaking(h) => {
+                ConnectionStateVariant::Handshaking(h.clone_ref(py))
+            }
+            ConnectionStateVariant::Connected(c) => {
+                ConnectionStateVariant::Connected(c.clone_ref(py))
+            }
+        })
+    }
+}
+
+impl ConnectionStateVariant {
+    pub fn into_py(self, _py: Python<'_>) -> PyObject {
+        match self {
+            ConnectionStateVariant::Handshaking(h) => h.into(),
+            ConnectionStateVariant::Connected(c) => c.into(),
+        }
+    }
+}
+
+impl ConnectionStateVariant {
+    pub fn from_rust(py: Python<'_>, state: &samod_core::network::ConnectionState) -> Self {
+        match state {
+            samod_core::network::ConnectionState::Handshaking => {
+                let handshaking = Bound::new(py, PyConnectionStateHandshaking::new())
+                    .unwrap()
+                    .unbind();
+                ConnectionStateVariant::Handshaking(handshaking)
+            }
+            samod_core::network::ConnectionState::Connected { their_peer_id } => {
+                let peer_id = PyPeerId(their_peer_id.clone());
+                let connected = Bound::new(py, PyConnectionStateConnected::new(peer_id))
+                    .unwrap()
+                    .unbind();
+                ConnectionStateVariant::Connected(connected)
+            }
+        }
+    }
+}
+
+// ===== Peer Document State =====
+
+/// Synchronization state for one (peer, document) pair
+#[pyclass(name = "PeerDocState")]
+#[derive(Clone)]
+pub struct PyPeerDocState {
+    /// When we last received a message from this peer for this document
+    #[pyo3(get)]
+    pub last_received: Option<f64>,
+
+    /// When we last sent a message to this peer for this document
+    #[pyo3(get)]
+    pub last_sent: Option<f64>,
+
+    /// The heads of the document when we last sent a message (as strings)
+    #[pyo3(get)]
+    pub last_sent_heads: Option<Vec<crate::PyChangeHash>>,
+
+    /// The last heads of the document that the peer said they had (as strings)
+    #[pyo3(get)]
+    pub last_acked_heads: Option<Vec<crate::PyChangeHash>>,
+}
+
+#[pymethods]
+impl PyPeerDocState {
+    fn __repr__(&self) -> String {
+        format!(
+            "PeerDocState(last_received={:?}, last_sent={:?}, sent_heads={}, acked_heads={})",
+            self.last_received,
+            self.last_sent,
+            self.last_sent_heads.as_ref().map_or(0, |v| v.len()),
+            self.last_acked_heads.as_ref().map_or(0, |v| v.len())
+        )
+    }
+}
+
+impl From<&samod_core::network::PeerDocState> for PyPeerDocState {
+    fn from(state: &samod_core::network::PeerDocState) -> Self {
+        PyPeerDocState {
+            last_received: state.last_received.map(|ts| ts.as_millis() as f64 / 1000.0),
+            last_sent: state.last_sent.map(|ts| ts.as_millis() as f64 / 1000.0),
+            last_sent_heads: state.last_sent_heads.as_ref().map(|heads| {
+                heads.iter().map(|h| crate::PyChangeHash(*h)).collect()
+            }),
+            last_acked_heads: state.last_acked_heads.as_ref().map(|heads| {
+                heads.iter().map(|h| crate::PyChangeHash(*h)).collect()
+            }),
+        }
+    }
+}
+
+// ===== Connection Info =====
+
+/// Information about a live connection
+#[pyclass(name = "ConnectionInfo")]
+#[derive(Clone)]
+pub struct PyConnectionInfo {
+    /// Connection ID
+    #[pyo3(get)]
+    pub id: PyConnectionId,
+
+    /// When we last received any message from this connection
+    #[pyo3(get)]
+    pub last_received: Option<f64>,
+
+    /// When we last sent any message to this connection
+    #[pyo3(get)]
+    pub last_sent: Option<f64>,
+
+    /// Connection state (handshaking or connected)
+    state: ConnectionStateVariant,
+
+    /// Synchronization state for each document (internal storage)
+    docs: HashMap<samod_core::DocumentId, PyPeerDocState>,
+}
+
+#[pymethods]
+impl PyConnectionInfo {
+    /// Get the connection state
+    #[getter]
+    fn state(&self, py: Python<'_>) -> PyObject {
+        self.state.clone().into_py(py)
+    }
+
+    /// Get the synchronization state for all documents
+    ///
+    /// Returns a dict mapping DocumentId to PeerDocState
+    fn docs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (doc_id, state) in &self.docs {
+            dict.set_item(PyDocumentId(doc_id.clone()), state.clone())?;
+        }
+        Ok(dict)
+    }
+
+    /// Get the synchronization state for a specific document
+    fn doc_state(&self, document_id: PyDocumentId) -> Option<PyPeerDocState> {
+        self.docs.get(&document_id.0).cloned()
+    }
+
+    fn __repr__(&self) -> String {
+        let state_str = match &self.state {
+            ConnectionStateVariant::Handshaking(_) => "Handshaking",
+            ConnectionStateVariant::Connected(_) => "Connected",
+        };
+        format!(
+            "ConnectionInfo(id={}, state={}, docs={})",
+            u32::from(self.id.0),
+            state_str,
+            self.docs.len()
+        )
+    }
+}
+
+impl PyConnectionInfo {
+    pub(crate) fn from_rust(py: Python<'_>, info: &samod_core::network::ConnectionInfo) -> Self {
+        PyConnectionInfo {
+            id: PyConnectionId(info.id),
+            last_received: info.last_received.map(|ts| ts.as_millis() as f64 / 1000.0),
+            last_sent: info.last_sent.map(|ts| ts.as_millis() as f64 / 1000.0),
+            state: ConnectionStateVariant::from_rust(py, &info.state),
+            docs: info.docs.iter()
+                .map(|(doc_id, state)| (doc_id.clone(), PyPeerDocState::from(state)))
+                .collect(),
+        }
+    }
+}

--- a/rust/src/repo/connection.rs
+++ b/rust/src/repo/connection.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::HashMap;
 
-use super::types::{PyConnectionId, PyPeerId, PyDocumentId};
+use super::types::{PyConnectionId, PyDocumentId, PyPeerId};
 
 // ===== Connection State =====
 
@@ -53,11 +53,17 @@ pub struct PyConnectionStateConnected {
 impl PyConnectionStateConnected {
     #[new]
     fn new(their_peer_id: PyPeerId) -> (Self, PyConnectionState) {
-        (PyConnectionStateConnected { their_peer_id }, PyConnectionState)
+        (
+            PyConnectionStateConnected { their_peer_id },
+            PyConnectionState,
+        )
     }
 
     fn __repr__(&self) -> String {
-        format!("ConnectionStateConnected(their_peer_id={})", self.their_peer_id.0)
+        format!(
+            "ConnectionStateConnected(their_peer_id={})",
+            self.their_peer_id.0
+        )
     }
 }
 
@@ -150,12 +156,14 @@ impl From<&samod_core::network::PeerDocState> for PyPeerDocState {
         PyPeerDocState {
             last_received: state.last_received.map(|ts| ts.as_millis() as f64 / 1000.0),
             last_sent: state.last_sent.map(|ts| ts.as_millis() as f64 / 1000.0),
-            last_sent_heads: state.last_sent_heads.as_ref().map(|heads| {
-                heads.iter().map(|h| crate::PyChangeHash(*h)).collect()
-            }),
-            last_acked_heads: state.last_acked_heads.as_ref().map(|heads| {
-                heads.iter().map(|h| crate::PyChangeHash(*h)).collect()
-            }),
+            last_sent_heads: state
+                .last_sent_heads
+                .as_ref()
+                .map(|heads| heads.iter().map(|h| crate::PyChangeHash(*h)).collect()),
+            last_acked_heads: state
+                .last_acked_heads
+                .as_ref()
+                .map(|heads| heads.iter().map(|h| crate::PyChangeHash(*h)).collect()),
         }
     }
 }
@@ -230,7 +238,9 @@ impl PyConnectionInfo {
             last_received: info.last_received.map(|ts| ts.as_millis() as f64 / 1000.0),
             last_sent: info.last_sent.map(|ts| ts.as_millis() as f64 / 1000.0),
             state: ConnectionStateVariant::from_rust(py, &info.state),
-            docs: info.docs.iter()
+            docs: info
+                .docs
+                .iter()
                 .map(|(doc_id, state)| (doc_id.clone(), PyPeerDocState::from(state)))
                 .collect(),
         }

--- a/rust/src/repo/document.rs
+++ b/rust/src/repo/document.rs
@@ -1,0 +1,442 @@
+//! Document actor types
+//!
+//! This module contains types related to document actors,
+//! including SpawnArgs, message types, and the DocumentActor itself.
+
+use pyo3::prelude::*;
+use std::sync::{Arc, Mutex};
+
+use super::io::PyIoTask;
+use super::types::{PyDocumentActorId, PyDocumentId};
+use crate::CURRENT_DOC_CONTEXT;
+
+/// Wrapper for samod_core::actors::document::SpawnArgs
+///
+/// Arguments for spawning a new document actor.
+#[pyclass(name = "SpawnArgs")]
+#[derive(Clone)]
+pub struct PySpawnArgs {
+    inner: samod_core::actors::document::SpawnArgs,
+}
+
+#[pymethods]
+impl PySpawnArgs {
+    /// Get the document actor ID
+    #[getter]
+    fn actor_id(&self) -> PyDocumentActorId {
+        PyDocumentActorId(self.inner.actor_id())
+    }
+
+    /// Get the document ID
+    #[getter]
+    fn document_id(&self) -> PyDocumentId {
+        PyDocumentId(self.inner.document_id().clone())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SpawnArgs(actor_id={}, document_id={})",
+            self.inner.actor_id(),
+            self.inner.document_id()
+        )
+    }
+}
+
+impl From<samod_core::actors::document::SpawnArgs> for PySpawnArgs {
+    fn from(args: samod_core::actors::document::SpawnArgs) -> Self {
+        PySpawnArgs { inner: args }
+    }
+}
+
+/// Wrapper for samod_core::actors::HubToDocMsg
+///
+/// Message sent from the Hub to a document actor.
+#[pyclass(name = "HubToDocMsg")]
+#[derive(Clone)]
+pub struct PyHubToDocMsg {
+    inner: samod_core::actors::HubToDocMsg,
+}
+
+#[pymethods]
+impl PyHubToDocMsg {
+    fn __repr__(&self) -> String {
+        "HubToDocMsg(...)".to_string()
+    }
+}
+
+impl From<samod_core::actors::HubToDocMsg> for PyHubToDocMsg {
+    fn from(msg: samod_core::actors::HubToDocMsg) -> Self {
+        PyHubToDocMsg { inner: msg }
+    }
+}
+
+/// Wrapper for samod_core::actors::DocToHubMsg
+///
+/// Message sent from a document actor to the Hub.
+#[pyclass(name = "DocToHubMsg")]
+#[derive(Clone)]
+pub struct PyDocToHubMsg {
+    pub(crate) inner: samod_core::actors::DocToHubMsg,
+}
+
+#[pymethods]
+impl PyDocToHubMsg {
+    fn __repr__(&self) -> String {
+        "DocToHubMsg(...)".to_string()
+    }
+}
+
+impl From<samod_core::actors::DocToHubMsg> for PyDocToHubMsg {
+    fn from(msg: samod_core::actors::DocToHubMsg) -> Self {
+        PyDocToHubMsg { inner: msg }
+    }
+}
+
+// ===== Document Actor Results =====
+
+/// Wrapper for samod_core::actors::document::DocActorResult
+///
+/// Result from processing a message in a document actor.
+#[pyclass(name = "DocActorResult")]
+pub struct PyDocActorResult {
+    pub(crate) inner: samod_core::actors::document::DocActorResult,
+}
+
+#[pymethods]
+impl PyDocActorResult {
+    /// Get IO tasks that need to be executed
+    #[getter]
+    fn io_tasks<'py>(&self, py: Python<'py>) -> Vec<PyIoTask> {
+        self.inner
+            .io_tasks
+            .iter()
+            .map(|task| super::io::document_io_task_ref_to_py(py, task.task_id, &task.action))
+            .collect()
+    }
+
+    /// Get messages to send to the Hub (outgoing messages)
+    #[getter]
+    fn outgoing_messages(&self) -> Vec<PyDocToHubMsg> {
+        self.inner
+            .outgoing_messages
+            .iter()
+            .map(|msg| PyDocToHubMsg::from(msg.clone()))
+            .collect()
+    }
+
+    /// Get ephemeral messages to send to the Hub
+    ///
+    /// These are serialized messages (Vec<u8>) for ephemeral data
+    #[getter]
+    fn ephemeral_messages<'py>(&self, py: Python<'py>) -> Vec<Bound<'py, pyo3::types::PyBytes>> {
+        self.inner
+            .ephemeral_messages
+            .iter()
+            .map(|msg_bytes| pyo3::types::PyBytes::new(py, msg_bytes))
+            .collect()
+    }
+
+    /// Check if the actor is stopped
+    #[getter]
+    fn stopped(&self) -> bool {
+        self.inner.stopped
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DocActorResult(io_tasks={}, outgoing_messages={}, ephemeral_messages={}, stopped={})",
+            self.inner.io_tasks.len(),
+            self.inner.outgoing_messages.len(),
+            self.inner.ephemeral_messages.len(),
+            self.inner.stopped
+        )
+    }
+}
+
+// ===== WithDoc Result =====
+
+/// Result from accessing a document via with_document
+#[pyclass(name = "WithDocResult")]
+pub struct PyWithDocResult {
+    /// The return value from the user's function (as a PyObject)
+    #[pyo3(get)]
+    pub return_value: PyObject,
+
+    /// Patches describing changes made during the callback
+    #[pyo3(get)]
+    pub patches: Vec<crate::PyPatch>,
+
+    pub(crate) inner: samod_core::actors::document::WithDocResult<()>,
+}
+
+#[pymethods]
+impl PyWithDocResult {
+    /// Get IO tasks that need to be executed
+    #[getter]
+    fn io_tasks<'py>(&self, py: Python<'py>) -> Vec<PyIoTask> {
+        self.inner
+            .actor_result
+            .io_tasks
+            .iter()
+            .map(|task| super::io::document_io_task_ref_to_py(py, task.task_id, &task.action))
+            .collect()
+    }
+
+    /// Get outgoing messages to send to the Hub
+    #[getter]
+    fn outgoing_messages(&self) -> Vec<PyDocToHubMsg> {
+        self.inner
+            .actor_result
+            .outgoing_messages
+            .iter()
+            .map(|msg| PyDocToHubMsg::from(msg.clone()))
+            .collect()
+    }
+
+    /// Get ephemeral messages to send to the Hub
+    ///
+    /// These are serialized messages (Vec<u8>) for ephemeral data
+    #[getter]
+    fn ephemeral_messages<'py>(&self, py: Python<'py>) -> Vec<Bound<'py, pyo3::types::PyBytes>> {
+        self.inner
+            .actor_result
+            .ephemeral_messages
+            .iter()
+            .map(|msg_bytes| pyo3::types::PyBytes::new(py, msg_bytes))
+            .collect()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "WithDocResult(io_tasks={}, outgoing={}, ephemeral={})",
+            self.inner.actor_result.io_tasks.len(),
+            self.inner.actor_result.outgoing_messages.len(),
+            self.inner.actor_result.ephemeral_messages.len()
+        )
+    }
+}
+
+// ===== Document Actor =====
+
+/// Wrapper for samod_core::actors::document::DocumentActor
+///
+/// The document actor manages a single Automerge document, handling
+/// persistence and synchronization for that document.
+#[pyclass(name = "DocumentActor")]
+pub struct PyDocumentActor {
+    // Use Arc<Mutex<...>> for thread safety across Python's async runtime
+    inner: Arc<Mutex<samod_core::actors::document::DocumentActor>>,
+}
+
+#[pymethods]
+impl PyDocumentActor {
+    /// Create a new document actor from spawn arguments
+    ///
+    /// Returns tuple of (DocumentActor, initial DocActorResult)
+    #[staticmethod]
+    fn new(now: f64, spawn_args: &PySpawnArgs) -> PyResult<(Self, PyDocActorResult)> {
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+        let (actor, initial_result) =
+            samod_core::actors::document::DocumentActor::new(timestamp, spawn_args.inner.clone());
+        Ok((
+            PyDocumentActor {
+                inner: Arc::new(Mutex::new(actor)),
+            },
+            PyDocActorResult {
+                inner: initial_result,
+            },
+        ))
+    }
+
+    /// Handle a message from the Hub
+    fn handle_message(&self, now: f64, msg: &PyHubToDocMsg) -> PyResult<PyDocActorResult> {
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+        let mut actor = self.inner.lock().unwrap();
+        let result = actor
+            .handle_message(timestamp, msg.inner.clone())
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                    "Document actor error: {:?}",
+                    e
+                ))
+            })?;
+        Ok(PyDocActorResult { inner: result })
+    }
+
+    /// Handle completion of an IO operation
+    fn handle_io_complete(
+        &self,
+        now: f64,
+        io_result: &super::io::PyIoResult,
+    ) -> PyResult<PyDocActorResult> {
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+        let mut actor = self.inner.lock().unwrap();
+
+        // Convert PyIoResult to Rust IoResult<DocumentIoResult>
+        let rust_io_result = io_result.to_document_io_result()?;
+
+        let result = actor
+            .handle_io_complete(timestamp, rust_io_result)
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                    "Document actor error: {:?}",
+                    e
+                ))
+            })?;
+        Ok(PyDocActorResult { inner: result })
+    }
+
+    /// Get a read-only document reference backed by this DocumentActor
+    ///
+    /// Returns a Document that acquires the actor's mutex on each read operation.
+    /// This allows direct property access without callbacks, with the trade-off
+    /// of mutex acquisition overhead per operation.
+    ///
+    /// The returned document is read-only. Any attempt to create a transaction
+    /// or modify it will result in an error.
+    ///
+    /// # Example
+    /// ```python
+    /// doc = actor.get_document()
+    /// value = doc.get(ROOT, "key")  # Acquires lock, reads, releases lock
+    /// ```
+    fn get_document(&self) -> PyResult<crate::Document> {
+        Ok(crate::Document::new_from_actor(self.inner.clone()))
+    }
+
+    /// Access the document with a Python callable
+    ///
+    /// The callable will receive a borrowed document reference that can be used
+    /// to read and modify the document. The callable's return value is captured
+    /// and returned in the WithDocResult.
+    fn with_document(&self, py: Python, now: f64, func: PyObject) -> PyResult<PyWithDocResult> {
+        use std::cell::RefCell;
+
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+
+        // Check if we're already in a change callback - nested changes are not supported
+        let already_in_callback = CURRENT_DOC_CONTEXT.with(|ctx| ctx.borrow().is_some());
+        if already_in_callback {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Cannot call change() inside another change() callback. \
+                 Nested changes are not supported. Please restructure your code \
+                 to perform changes sequentially rather than nesting them.",
+            ));
+        }
+
+        // Capture the Arc identity for this actor
+        let arc_id = Arc::as_ptr(&self.inner) as usize;
+
+        let mut actor = self.inner.lock().unwrap();
+
+        // Use RefCell to capture the return value, patches, and potential errors from the Python function
+        let return_value_cell: RefCell<Option<PyObject>> = RefCell::new(None);
+        let patches_cell: RefCell<Vec<crate::PyPatch>> = RefCell::new(Vec::new());
+        let error_cell: RefCell<Option<PyErr>> = RefCell::new(None);
+
+        // Call with_document with a closure that invokes the Python function
+        let result = actor
+            .with_document(timestamp, |doc| {
+                // Set thread-local context for reentrant access
+                // This allows doc() references to work inside change() callbacks
+                CURRENT_DOC_CONTEXT.with(|ctx| {
+                    *ctx.borrow_mut() = Some((arc_id, doc as *const automerge::Automerge));
+                });
+
+                // Capture heads before the callback
+                let before_heads: Vec<_> = doc.get_heads().iter().cloned().collect();
+
+                // We need to acquire the GIL to call Python code
+                Python::with_gil(|py| {
+                    // Create a borrowed document wrapper around the mutable reference
+                    // SAFETY: The Document only exists within this callback scope,
+                    // and the pointer is guaranteed valid for the duration of the Python call.
+                    // The Python callback executes synchronously and cannot store the reference.
+                    let borrowed_doc = unsafe { crate::Document::new_borrowed(doc) };
+
+                    // Convert to Python object
+                    let py_doc_obj = match Py::new(py, borrowed_doc) {
+                        Ok(obj) => obj,
+                        Err(e) => {
+                            *error_cell.borrow_mut() = Some(e);
+                            return;
+                        }
+                    };
+
+                    // Call the Python function with the borrowed document
+                    let ret = match func.call1(py, (&py_doc_obj,)) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            // Capture the error to be raised after the closure completes
+                            *error_cell.borrow_mut() = Some(e);
+                            // Invalidate the borrowed document before returning
+                            py_doc_obj.borrow(py).invalidate();
+                            return;
+                        }
+                    };
+
+                    // Store the return value
+                    *return_value_cell.borrow_mut() = Some(ret);
+
+                    // Invalidate the borrowed document to prevent use-after-callback
+                    // Even if someone holds a reference to py_doc_obj after this,
+                    // they'll get a clear panic instead of undefined behavior
+                    py_doc_obj.borrow(py).invalidate();
+
+                    // py_doc_obj is dropped here, which is safe because we're still in the callback
+                });
+
+                // Clear thread-local context immediately after the Python callback
+                // This must happen whether the callback succeeded or failed
+                CURRENT_DOC_CONTEXT.with(|ctx| {
+                    *ctx.borrow_mut() = None;
+                });
+
+                // Check if an error occurred during the Python callback
+                if error_cell.borrow().is_some() {
+                    // Don't generate patches if there was an error
+                    return ();
+                }
+
+                // Capture heads after the callback
+                let after_heads: Vec<_> = doc.get_heads().iter().cloned().collect();
+
+                // Generate patches if heads changed
+                if before_heads != after_heads {
+                    let patches = doc.diff(&before_heads, &after_heads);
+                    *patches_cell.borrow_mut() = patches
+                        .into_iter()
+                        .map(|p| crate::PyPatch(p.clone()))
+                        .collect();
+                }
+
+                // Return unit type for Rust
+                ()
+            })
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                    "Document actor error: {:?}",
+                    e
+                ))
+            })?;
+
+        // Check if an error occurred during the Python callback and raise it
+        if let Some(err) = error_cell.into_inner() {
+            return Err(err);
+        }
+
+        // Extract the return value and patches
+        let return_value = return_value_cell.into_inner().unwrap_or_else(|| py.None());
+        let patches = patches_cell.into_inner();
+
+        Ok(PyWithDocResult {
+            return_value,
+            patches,
+            inner: result,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "DocumentActor(...)".to_string()
+    }
+}

--- a/rust/src/repo/document.rs
+++ b/rust/src/repo/document.rs
@@ -4,6 +4,7 @@
 //! including SpawnArgs, message types, and the DocumentActor itself.
 
 use pyo3::prelude::*;
+use samod_core::actors::document::document_actor::WithDocGuard;
 use std::sync::{Arc, Mutex};
 
 use super::io::PyIoTask;
@@ -304,139 +305,313 @@ impl PyDocumentActor {
         Ok(crate::Document::new_from_actor(self.inner.clone()))
     }
 
-    /// Access the document with a Python callable
+    fn __repr__(&self) -> String {
+        "DocumentActor(...)".to_string()
+    }
+
+    /// Begin a change session for the context manager API.
     ///
-    /// The callable will receive a borrowed document reference that can be used
-    /// to read and modify the document. The callable's return value is captured
-    /// and returned in the WithDocResult.
-    fn with_document(&self, py: Python, now: f64, func: PyObject) -> PyResult<PyWithDocResult> {
-        use std::cell::RefCell;
-
-        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
-
-        // Check if we're already in a change callback - nested changes are not supported
-        let already_in_callback = CURRENT_DOC_CONTEXT.with(|ctx| ctx.borrow().is_some());
-        if already_in_callback {
+    /// Returns a ChangeGuard that holds the mutex and allows modifications.
+    /// The guard must be ended via end_change() to commit or rollback.
+    fn begin_change(&self, py: Python) -> PyResult<ChangeGuard> {
+        // Check if we're already in a change - nested changes are not supported
+        let already_in_change = CURRENT_DOC_CONTEXT.with(|ctx| ctx.borrow().is_some());
+        if already_in_change {
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "Cannot call change() inside another change() callback. \
-                 Nested changes are not supported. Please restructure your code \
+                "Cannot nest change() calls. Please restructure your code \
                  to perform changes sequentially rather than nesting them.",
             ));
         }
 
-        // Capture the Arc identity for this actor
         let arc_id = Arc::as_ptr(&self.inner) as usize;
 
-        let mut actor = self.inner.lock().unwrap();
+        // Create the session wrapper which handles all unsafe lifetime management
+        let mut session = ChangeSession::new(self.inner.clone())?;
 
-        // Use RefCell to capture the return value, patches, and potential errors from the Python function
-        let return_value_cell: RefCell<Option<PyObject>> = RefCell::new(None);
-        let patches_cell: RefCell<Vec<crate::PyPatch>> = RefCell::new(Vec::new());
-        let error_cell: RefCell<Option<PyErr>> = RefCell::new(None);
+        // Get the document pointer from the session
+        let doc_ptr = session.doc_ptr();
 
-        // Call with_document with a closure that invokes the Python function
-        let result = actor
-            .with_document(timestamp, |doc| {
-                // Set thread-local context for reentrant access
-                // This allows doc() references to work inside change() callbacks
-                CURRENT_DOC_CONTEXT.with(|ctx| {
-                    *ctx.borrow_mut() = Some((arc_id, doc as *const automerge::Automerge));
-                });
+        // Capture heads before modification for patch generation
+        // SAFETY: doc_ptr is valid as long as session is alive
+        let before_heads: Vec<_> = unsafe { &*doc_ptr }.get_heads().iter().cloned().collect();
 
-                // Capture heads before the callback
-                let before_heads: Vec<_> = doc.get_heads().iter().cloned().collect();
+        // Create borrowed Document wrapper
+        // SAFETY: The document pointer is valid as long as the session is held
+        // because the session is holding a reference to the DocumentActor
+        let borrowed_doc = unsafe { crate::Document::new_borrowed(&mut *doc_ptr) };
+        let py_doc = Py::new(py, borrowed_doc)?;
 
-                // We need to acquire the GIL to call Python code
-                Python::with_gil(|py| {
-                    // Create a borrowed document wrapper around the mutable reference
-                    // SAFETY: The Document only exists within this callback scope,
-                    // and the pointer is guaranteed valid for the duration of the Python call.
-                    // The Python callback executes synchronously and cannot store the reference.
-                    let borrowed_doc = unsafe { crate::Document::new_borrowed(doc) };
+        // Create transaction on the borrowed document
+        let mut doc_ref = py_doc.borrow_mut(py);
+        let py_tx = doc_ref.transaction()?;
+        drop(doc_ref);
+        let py_tx = Py::new(py, py_tx)?;
 
-                    // Convert to Python object
-                    let py_doc_obj = match Py::new(py, borrowed_doc) {
-                        Ok(obj) => obj,
-                        Err(e) => {
-                            *error_cell.borrow_mut() = Some(e);
-                            return;
-                        }
-                    };
+        // Set thread-local context to mark this actor as in-change
+        // change() calls can detect and error
+        CURRENT_DOC_CONTEXT.with(|ctx| {
+            *ctx.borrow_mut() = Some(arc_id);
+        });
 
-                    // Call the Python function with the borrowed document
-                    let ret = match func.call1(py, (&py_doc_obj,)) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            // Capture the error to be raised after the closure completes
-                            *error_cell.borrow_mut() = Some(e);
-                            // Invalidate the borrowed document before returning
-                            py_doc_obj.borrow(py).invalidate();
-                            return;
-                        }
-                    };
+        Ok(ChangeGuard {
+            session: Some(session),
+            document: Some(py_doc),
+            transaction: Some(py_tx),
+            before_heads,
+            arc_id,
+        })
+    }
+}
 
-                    // Store the return value
-                    *return_value_cell.borrow_mut() = Some(ret);
+/// A safety wrapper ensuring correct lifetime management for the actor lock and document guard.
+///
+/// # Safety Invariants
+///
+/// This struct maintains several critical safety invariants that must be preserved to avoid
+/// Undefined Behavior (UB), primarily Use-After-Free (UAF) and Data Races.
+///
+/// 1. **Anchor Liveness**: The `_anchor` field holds a strong `Arc` reference to the `Mutex`.
+///    This ensures the `Mutex`'s memory is not deallocated while `actor_guard` references it.
+///    Even if all external references to the actor are dropped (e.g., Python `actor` object is GC'd),
+///    this session keeps the underlying Mutex alive.
+///
+/// 2. **Stable Guard Address**: The `actor_guard` is boxed immediately after locking.
+///    This pins the `MutexGuard` to a stable heap address. This is required because
+///    `with_doc_guard` borrows from it. If `actor_guard` moved, the borrow would be invalidated.
+///
+/// 3. **Drop Order (Borrower before Owner)**: `with_doc_guard` borrows from `actor_guard`.
+///    Therefore, `with_doc_guard` MUST be dropped before `actor_guard`.
+///    - The `Drop` implementation explicitly drops `with_doc_guard` first.
+///    - The `commit` method consumes `with_doc_guard` before `actor_guard` is dropped.
+///
+/// 4. **Lifetime Confinement**: We use `unsafe` to transmute lifetimes to `'static`.
+///    This is valid ONLY because:
+///    - We own all the involved objects in this struct.
+///    - We never expose the `'static` references outside this struct's interface.
+///    - We strictly enforce the internal dependency order in `Drop` and `commit`.
+struct ChangeSession {
+    /// The anchor keeping the Mutex alive.
+    _anchor: Arc<Mutex<samod_core::actors::document::DocumentActor>>,
 
-                    // Invalidate the borrowed document to prevent use-after-callback
-                    // Even if someone holds a reference to py_doc_obj after this,
-                    // they'll get a clear panic instead of undefined behavior
-                    py_doc_obj.borrow(py).invalidate();
+    /// The owner of the lock. Dropped LAST.
+    /// Wrapped in Option to allow taking in Drop/commit.
+    actor_guard:
+        Option<Box<std::sync::MutexGuard<'static, samod_core::actors::document::DocumentActor>>>,
 
-                    // py_doc_obj is dropped here, which is safe because we're still in the callback
-                });
+    /// The borrower of the lock. Dropped FIRST.
+    with_doc_guard: Option<WithDocGuard<'static>>,
+}
 
-                // Clear thread-local context immediately after the Python callback
-                // This must happen whether the callback succeeded or failed
-                CURRENT_DOC_CONTEXT.with(|ctx| {
-                    *ctx.borrow_mut() = None;
-                });
+impl ChangeSession {
+    /// Create a new session. This locks the mutex and prepares the guards.
+    fn new(anchor: Arc<Mutex<samod_core::actors::document::DocumentActor>>) -> PyResult<Self> {
+        // 1. Acquire the lock
+        let guard = anchor.lock().map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to acquire actor lock: {}",
+                e
+            ))
+        })?;
 
-                // Check if an error occurred during the Python callback
-                if error_cell.borrow().is_some() {
-                    // Don't generate patches if there was an error
-                    return ();
-                }
+        // 2. Box to pin memory address
+        let boxed_guard = Box::new(guard);
 
-                // Capture heads after the callback
-                let after_heads: Vec<_> = doc.get_heads().iter().cloned().collect();
+        // 3. Transmute guard to 'static
+        // SAFETY: We hold `_anchor` which ensures the Mutex outlives this struct.
+        // We hold `boxed_guard` which ensures the Guard outlives the fields that borrow from it.
+        let mut static_actor_guard: Box<
+            std::sync::MutexGuard<'static, samod_core::actors::document::DocumentActor>,
+        > = unsafe { std::mem::transmute(boxed_guard) };
 
-                // Generate patches if heads changed
-                if before_heads != after_heads {
-                    let patches = doc.diff(&before_heads, &after_heads);
-                    *patches_cell.borrow_mut() = patches
-                        .into_iter()
-                        .map(|p| crate::PyPatch(p.clone()))
-                        .collect();
-                }
+        // 4. Create the borrower
+        // Note: begin_modification() takes &mut DocumentActor
+        let with_doc_guard = static_actor_guard.begin_modification().map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to begin modification: {:?}",
+                e
+            ))
+        })?;
 
-                // Return unit type for Rust
-                ()
-            })
-            .map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Document actor error: {:?}",
-                    e
-                ))
-            })?;
+        // 5. Transmute borrower to 'static
+        // SAFETY: We ensure in `Drop` and `commit` that this field is destroyed before `actor_guard`.
+        let static_with_doc_guard: WithDocGuard<'static> =
+            unsafe { std::mem::transmute(with_doc_guard) };
 
-        // Check if an error occurred during the Python callback and raise it
-        if let Some(err) = error_cell.into_inner() {
-            return Err(err);
-        }
-
-        // Extract the return value and patches
-        let return_value = return_value_cell.into_inner().unwrap_or_else(|| py.None());
-        let patches = patches_cell.into_inner();
-
-        Ok(PyWithDocResult {
-            return_value,
-            patches,
-            inner: result,
+        Ok(Self {
+            _anchor: anchor,
+            actor_guard: Some(static_actor_guard),
+            with_doc_guard: Some(static_with_doc_guard),
         })
     }
 
-    fn __repr__(&self) -> String {
-        "DocumentActor(...)".to_string()
+    /// Access the raw document pointer.
+    fn doc_ptr(&mut self) -> *mut automerge::Automerge {
+        // SAFETY: Unwrapping is safe because None only happens during Drop/Commit
+        self.with_doc_guard.as_mut().unwrap().doc() as *mut automerge::Automerge
+    }
+
+    /// Commit the changes and consume the session.
+    fn commit(
+        mut self,
+        timestamp: samod_core::UnixTimestamp,
+    ) -> samod_core::actors::document::DocActorResult {
+        // 1. Take borrower
+        let with_doc = self.with_doc_guard.take().expect("Session already closed");
+
+        // 2. Commit (consumes borrower)
+        let result = with_doc.commit(timestamp);
+
+        // 3. `self` drops here.
+        // `actor_guard` is still in `self.actor_guard`.
+        // `Drop` will run. It will see `with_doc_guard` is None (we took it), so it will just drop `actor_guard`.
+        // Then `_anchor` drops.
+        // Everything happens in safe order.
+        result
+    }
+}
+
+impl Drop for ChangeSession {
+    fn drop(&mut self) {
+        // If we are dropping (e.g. rollback or panic), we must ensure order.
+        if self.with_doc_guard.is_some() {
+            // 1. Drop borrower
+            self.with_doc_guard.take();
+            // 2. Drop owner (releases lock)
+            self.actor_guard.take();
+            // 3. Anchor drops naturally
+        }
+    }
+}
+
+/// Guard for a document change session (context manager support).
+///
+/// This holds the mutex lock and allows modifications to the document.
+/// Must be ended via end_change() to commit or rollback the changes.
+///
+/// This type is not thread-safe (unsendable) because it holds a MutexGuard.
+#[pyclass(name = "ChangeGuard", unsendable)]
+pub struct ChangeGuard {
+    /// The session wrapper handling lifetime safety
+    session: Option<ChangeSession>,
+
+    /// Borrowed document wrapping the guard's document_mut()
+    document: Option<Py<crate::Document>>,
+
+    /// Transaction on the borrowed document
+    transaction: Option<Py<crate::Transaction>>,
+
+    /// Heads before modification, for generating patches
+    before_heads: Vec<automerge::ChangeHash>,
+
+    /// Arc pointer address for thread-local cleanup
+    #[allow(dead_code)]
+    arc_id: usize,
+}
+
+#[pymethods]
+impl ChangeGuard {
+    /// Get the transaction for this change session.
+    fn transaction(&self, py: Python) -> PyResult<Py<crate::Transaction>> {
+        match &self.transaction {
+            Some(tx) => Ok(tx.clone_ref(py)),
+            None => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Change already ended",
+            )),
+        }
+    }
+
+    /// End the change session, committing or rolling back.
+    ///
+    /// Args:
+    ///     commit: If true, commit the transaction. If false, rollback.
+    ///     now: Current timestamp as seconds since epoch.
+    ///
+    /// Returns:
+    ///     WithDocResult containing patches, IO tasks, and messages.
+    fn end_change(&mut self, py: Python, commit: bool, now: f64) -> PyResult<PyWithDocResult> {
+        // Take the transaction first
+        let transaction = self.transaction.take();
+        let document = self.document.take();
+
+        // Clear thread-local context immediately
+        CURRENT_DOC_CONTEXT.with(|ctx| {
+            *ctx.borrow_mut() = None;
+        });
+
+        // Commit or rollback the automerge transaction
+        if let Some(tx) = &transaction {
+            let tx_ref = tx.bind(py);
+            if commit {
+                tx_ref.call_method0("commit")?;
+            } else {
+                tx_ref.call_method0("rollback")?;
+            }
+        }
+
+        // Generate patches by diffing before/after heads
+        let patches = if let Some(ref doc) = document {
+            let doc_ref = doc.bind(py);
+            let after_heads: Vec<crate::PyChangeHash> =
+                doc_ref.call_method0("get_heads")?.extract()?;
+            let before: Vec<crate::PyChangeHash> = self
+                .before_heads
+                .iter()
+                .map(|h| crate::PyChangeHash(*h))
+                .collect();
+
+            if before.iter().map(|h| h.0).collect::<Vec<_>>()
+                != after_heads.iter().map(|h| h.0).collect::<Vec<_>>()
+            {
+                let patches: Vec<crate::PyPatch> = doc_ref
+                    .call_method1("diff", (before, after_heads))?
+                    .extract()?;
+                patches
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        // Invalidate borrowed document
+        if let Some(doc) = &document {
+            doc.borrow(py).invalidate();
+        }
+
+        // Commit the session
+        // This consumes the WithDocGuard and releases the lock
+        let session = self.session.take().ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Change already ended")
+        })?;
+
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+        let actor_result = session.commit(timestamp);
+
+        // Build result - we use a dummy WithDocResult since we generated patches ourselves
+        let inner =
+            samod_core::actors::document::WithDocResult::with_side_effects((), actor_result);
+
+        Ok(PyWithDocResult {
+            return_value: py.None(),
+            patches,
+            inner,
+        })
+    }
+}
+
+impl Drop for ChangeGuard {
+    fn drop(&mut self) {
+        // Panic if session still exists - end_change must always be called
+        // The Python __exit__ implementation is responsible for ensuring this
+        if self.session.is_some() {
+            // Clear thread-local context before panicking to avoid leaving stale state
+            CURRENT_DOC_CONTEXT.with(|ctx| {
+                *ctx.borrow_mut() = None;
+            });
+            panic!(
+                "ChangeGuard dropped without calling end_change(). \
+                 The ChangeContext.__exit__ must always call end_change()."
+            );
+        }
     }
 }

--- a/rust/src/repo/hub.rs
+++ b/rust/src/repo/hub.rs
@@ -1,0 +1,87 @@
+//! Hub actor
+//!
+//! This module contains the Hub type, which is the central coordinator
+//! for the repository.
+
+use pyo3::prelude::*;
+
+use super::types::{PyPeerId, PyStorageId};
+use super::hub_events::PyHubEvent;
+use super::hub_results::PyHubResults;
+
+/// Wrapper for samod_core::actors::hub::Hub
+///
+/// The Hub is the central coordinator for the repository. It manages
+/// document actors, connections, and storage operations.
+#[pyclass(name = "Hub")]
+pub struct PyHub {
+    pub(crate) inner: std::sync::Arc<std::sync::Mutex<samod_core::actors::hub::Hub>>,
+}
+
+#[pymethods]
+impl PyHub {
+    /// Get the storage ID for this Hub
+    ///
+    /// The storage ID identifies the storage layer this peer is connected to.
+    fn storage_id(&self) -> PyStorageId {
+        let guard = self.inner.lock().unwrap();
+        PyStorageId(guard.storage_id())
+    }
+
+    /// Get the peer ID for this Hub
+    ///
+    /// The peer ID is a unique identifier for this specific peer instance.
+    fn peer_id(&self) -> PyPeerId {
+        let guard = self.inner.lock().unwrap();
+        PyPeerId(guard.peer_id())
+    }
+
+    /// Check if this Hub has been stopped
+    fn is_stopped(&self) -> bool {
+        let guard = self.inner.lock().unwrap();
+        guard.is_stopped()
+    }
+
+    /// Get information about all active connections
+    ///
+    /// Returns a list of ConnectionInfo objects describing each active connection,
+    /// including connection state, peer information, and per-document sync state.
+    fn connections(&self, py: Python<'_>) -> Vec<super::connection::PyConnectionInfo> {
+        let guard = self.inner.lock().unwrap();
+        guard.connections()
+            .iter()
+            .map(|info| super::connection::PyConnectionInfo::from_rust(py, info))
+            .collect()
+    }
+
+    /// Handle an event and return the results
+    ///
+    /// This is the main interface for interacting with the Hub. Events can be
+    /// commands to execute, IO completion notifications, or network messages.
+    ///
+    /// Args:
+    ///     now: Current Unix timestamp in seconds (float)
+    ///     event: The event to process
+    ///
+    /// Returns:
+    ///     HubResults containing new tasks and completed commands
+    fn handle_event<'py>(&self, py: Python<'py>, now: f64, event: &PyHubEvent) -> PyResult<PyHubResults> {
+        let mut guard = self.inner.lock().unwrap();
+        let mut rng = rand::rng();
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+
+        // Convert PyHubEvent to samod_core::HubEvent
+        let rust_event = event.to_rust_event();
+
+        let results = guard.handle_event(&mut rng, timestamp, rust_event);
+
+        PyHubResults::from_rust(py, results)
+    }
+
+    fn __repr__(&self) -> String {
+        let guard = self.inner.lock().unwrap();
+        let peer_id = guard.peer_id();
+        let stopped = guard.is_stopped();
+        format!("Hub(peer_id={}, stopped={})", peer_id.as_str(), stopped)
+    }
+}

--- a/rust/src/repo/hub.rs
+++ b/rust/src/repo/hub.rs
@@ -5,9 +5,9 @@
 
 use pyo3::prelude::*;
 
-use super::types::{PyPeerId, PyStorageId};
 use super::hub_events::PyHubEvent;
 use super::hub_results::PyHubResults;
+use super::types::{PyPeerId, PyStorageId};
 
 /// Wrapper for samod_core::actors::hub::Hub
 ///
@@ -48,7 +48,8 @@ impl PyHub {
     /// including connection state, peer information, and per-document sync state.
     fn connections(&self, py: Python<'_>) -> Vec<super::connection::PyConnectionInfo> {
         let guard = self.inner.lock().unwrap();
-        guard.connections()
+        guard
+            .connections()
             .iter()
             .map(|info| super::connection::PyConnectionInfo::from_rust(py, info))
             .collect()
@@ -65,7 +66,12 @@ impl PyHub {
     ///
     /// Returns:
     ///     HubResults containing new tasks and completed commands
-    fn handle_event<'py>(&self, py: Python<'py>, now: f64, event: &PyHubEvent) -> PyResult<PyHubResults> {
+    fn handle_event<'py>(
+        &self,
+        py: Python<'py>,
+        now: f64,
+        event: &PyHubEvent,
+    ) -> PyResult<PyHubResults> {
         let mut guard = self.inner.lock().unwrap();
         let mut rng = rand::rng();
         let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);

--- a/rust/src/repo/hub_events.rs
+++ b/rust/src/repo/hub_events.rs
@@ -1,0 +1,204 @@
+//! Hub event types
+//!
+//! This module contains types for events sent to the Hub,
+//! including PeerInfo, ConnDirection, and HubEvent.
+
+use pyo3::prelude::*;
+
+use super::types::{PyPeerId, PyConnectionId, PyDocumentActorId, PyDocumentId};
+use super::document::{PyDocToHubMsg};
+use super::commands::PyDispatchedCommand;
+use super::io::PyIoResult;
+
+/// Wrapper for samod_core::network::PeerInfo
+///
+/// Information about a connected peer after successful handshake.
+#[pyclass(name = "PeerInfo")]
+#[derive(Clone)]
+pub struct PyPeerInfo {
+    pub(crate) inner: samod_core::network::PeerInfo,
+}
+
+#[pymethods]
+impl PyPeerInfo {
+    /// Get the peer ID
+    #[getter]
+    fn peer_id(&self) -> PyPeerId {
+        PyPeerId(self.inner.peer_id.clone())
+    }
+
+    /// Get the protocol version
+    #[getter]
+    fn protocol_version(&self) -> String {
+        self.inner.protocol_version.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("PeerInfo(peer_id={}, protocol_version={})",
+                self.inner.peer_id.as_str(), self.inner.protocol_version)
+    }
+}
+
+impl From<samod_core::network::PeerInfo> for PyPeerInfo {
+    fn from(info: samod_core::network::PeerInfo) -> Self {
+        PyPeerInfo { inner: info }
+    }
+}
+
+/// Wrapper for samod_core::network::ConnDirection
+///
+/// Indicates whether a connection is outgoing or incoming.
+#[pyclass(name = "ConnDirection")]
+#[derive(Clone, Copy)]
+pub enum PyConnDirection {
+    /// Connection initiated by this peer
+    Outgoing,
+    /// Connection accepted from a remote peer
+    Incoming,
+}
+
+impl From<PyConnDirection> for samod_core::network::ConnDirection {
+    fn from(dir: PyConnDirection) -> Self {
+        match dir {
+            PyConnDirection::Outgoing => samod_core::network::ConnDirection::Outgoing,
+            PyConnDirection::Incoming => samod_core::network::ConnDirection::Incoming,
+        }
+    }
+}
+
+/// Wrapper for samod_core::actors::hub::HubEvent
+///
+/// Represents an event that can be sent to the Hub for processing.
+#[pyclass(name = "HubEvent")]
+#[derive(Clone)]
+pub struct PyHubEvent {
+    pub(crate) inner: samod_core::actors::hub::HubEvent,
+}
+
+#[pymethods]
+impl PyHubEvent {
+    /// Create an event indicating that an IO task has completed
+    ///
+    /// Args:
+    ///     io_result: The result of the IO operation
+    #[staticmethod]
+    fn io_complete(io_result: PyIoResult) -> Self {
+        PyHubEvent {
+            inner: samod_core::actors::hub::HubEvent::io_complete(io_result.to_core()),
+        }
+    }
+
+    /// Create a tick event for periodic processing
+    #[staticmethod]
+    fn tick() -> Self {
+        PyHubEvent {
+            inner: samod_core::actors::hub::HubEvent::tick(),
+        }
+    }
+
+    /// Create an event indicating that a connection was lost externally
+    ///
+    /// Args:
+    ///     connection_id: The ID of the connection that was lost
+    #[staticmethod]
+    fn connection_lost(connection_id: PyConnectionId) -> Self {
+        PyHubEvent {
+            inner: samod_core::actors::hub::HubEvent::connection_lost(connection_id.0),
+        }
+    }
+
+    /// Create an event to stop the Hub
+    #[staticmethod]
+    fn stop() -> Self {
+        PyHubEvent {
+            inner: samod_core::actors::hub::HubEvent::stop(),
+        }
+    }
+
+    /// Create an event indicating that a message was received from a document actor
+    ///
+    /// Args:
+    ///     actor_id: The ID of the actor that sent the message
+    ///     message: The message from the actor
+    #[staticmethod]
+    fn actor_message(actor_id: PyDocumentActorId, message: PyDocToHubMsg) -> Self {
+        PyHubEvent {
+            inner: samod_core::actors::hub::HubEvent::actor_message(actor_id.0, message.inner),
+        }
+    }
+
+    /// Create a command to receive a message on a connection
+    ///
+    /// Args:
+    ///     connection_id: The ID of the connection
+    ///     msg: The message bytes
+    ///
+    /// Returns:
+    ///     DispatchedCommand with command_id and event
+    #[staticmethod]
+    fn receive(connection_id: PyConnectionId, msg: Vec<u8>) -> PyDispatchedCommand {
+        let dispatched = samod_core::actors::hub::HubEvent::receive(connection_id.0, msg);
+        PyDispatchedCommand::new(dispatched.command_id, dispatched.event)
+    }
+
+    /// Create a command to create a new connection
+    ///
+    /// Args:
+    ///     direction: Whether this is an outgoing or incoming connection
+    ///
+    /// Returns:
+    ///     DispatchedCommand with command_id and event
+    #[staticmethod]
+    fn create_connection(direction: PyConnDirection) -> PyDispatchedCommand {
+        let dispatched = samod_core::actors::hub::HubEvent::create_connection(direction.into());
+        PyDispatchedCommand::new(dispatched.command_id, dispatched.event)
+    }
+
+    /// Create a command to create a new document
+    ///
+    /// Returns:
+    ///     DispatchedCommand with command_id and event
+    #[staticmethod]
+    fn create_document() -> PyDispatchedCommand {
+        let doc = automerge::Automerge::new();
+        let dispatched = samod_core::actors::hub::HubEvent::create_document(doc);
+        PyDispatchedCommand::new(dispatched.command_id, dispatched.event)
+    }
+
+    /// Create a command to find an existing document
+    ///
+    /// Args:
+    ///     document_id: The ID of the document to find
+    ///
+    /// Returns:
+    ///     DispatchedCommand with command_id and event
+    #[staticmethod]
+    fn find_document(document_id: PyDocumentId) -> PyDispatchedCommand {
+        let dispatched = samod_core::actors::hub::HubEvent::find_document(document_id.0);
+        PyDispatchedCommand::new(dispatched.command_id, dispatched.event)
+    }
+
+    /// Create a command indicating that a document actor is ready
+    ///
+    /// Args:
+    ///     document_id: The ID of the document
+    ///
+    /// Returns:
+    ///     DispatchedCommand with command_id and event
+    #[staticmethod]
+    fn actor_ready(document_id: PyDocumentId) -> PyDispatchedCommand {
+        let dispatched = samod_core::actors::hub::HubEvent::actor_ready(document_id.0);
+        PyDispatchedCommand::new(dispatched.command_id, dispatched.event)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("HubEvent(...)")
+    }
+}
+
+impl PyHubEvent {
+    /// Convert to Rust HubEvent
+    pub(crate) fn to_rust_event(&self) -> samod_core::actors::hub::HubEvent {
+        self.inner.clone()
+    }
+}

--- a/rust/src/repo/hub_events.rs
+++ b/rust/src/repo/hub_events.rs
@@ -5,10 +5,10 @@
 
 use pyo3::prelude::*;
 
-use super::types::{PyPeerId, PyConnectionId, PyDocumentActorId, PyDocumentId};
-use super::document::{PyDocToHubMsg};
 use super::commands::PyDispatchedCommand;
+use super::document::PyDocToHubMsg;
 use super::io::PyIoResult;
+use super::types::{PyConnectionId, PyDocumentActorId, PyDocumentId, PyPeerId};
 
 /// Wrapper for samod_core::network::PeerInfo
 ///
@@ -34,8 +34,11 @@ impl PyPeerInfo {
     }
 
     fn __repr__(&self) -> String {
-        format!("PeerInfo(peer_id={}, protocol_version={})",
-                self.inner.peer_id.as_str(), self.inner.protocol_version)
+        format!(
+            "PeerInfo(peer_id={}, protocol_version={})",
+            self.inner.peer_id.as_str(),
+            self.inner.protocol_version
+        )
     }
 }
 

--- a/rust/src/repo/hub_results.rs
+++ b/rust/src/repo/hub_results.rs
@@ -1,0 +1,239 @@
+//! Hub result types
+//!
+//! This module contains types for results returned from Hub event processing,
+//! including ConnectionEvent variants and HubResults.
+
+use pyo3::prelude::*;
+
+use super::commands::{command_result_to_py, PyCommandId};
+use super::document::{PyHubToDocMsg, PySpawnArgs};
+use super::hub_events::PyPeerInfo;
+use super::io::PyIoTask;
+use super::types::{PyConnectionId, PyDocumentActorId};
+
+// ===== Connection Event =====
+
+/// HandshakeCompleted event - connection handshake successfully completed
+#[pyclass(name = "ConnectionEventHandshakeCompleted")]
+#[derive(Clone)]
+pub struct PyConnectionEventHandshakeCompleted {
+    #[pyo3(get)]
+    connection_id: PyConnectionId,
+    #[pyo3(get)]
+    peer_info: PyPeerInfo,
+}
+
+#[pymethods]
+impl PyConnectionEventHandshakeCompleted {
+    #[new]
+    fn new(connection_id: PyConnectionId, peer_info: PyPeerInfo) -> Self {
+        PyConnectionEventHandshakeCompleted {
+            connection_id,
+            peer_info,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ConnectionEventHandshakeCompleted(connection_id={:?}, peer_id={})",
+            self.connection_id.0,
+            self.peer_info.inner.peer_id.as_str()
+        )
+    }
+}
+
+/// ConnectionFailed event - connection attempt failed
+#[pyclass(name = "ConnectionEventConnectionFailed")]
+#[derive(Clone)]
+pub struct PyConnectionEventConnectionFailed {
+    #[pyo3(get)]
+    connection_id: PyConnectionId,
+    #[pyo3(get)]
+    error: String,
+}
+
+#[pymethods]
+impl PyConnectionEventConnectionFailed {
+    #[new]
+    fn new(connection_id: PyConnectionId, error: String) -> Self {
+        PyConnectionEventConnectionFailed {
+            connection_id,
+            error,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ConnectionEventConnectionFailed(connection_id={:?}, error={})",
+            self.connection_id.0, self.error
+        )
+    }
+}
+
+/// StateChanged event - connection state has changed
+#[pyclass(name = "ConnectionEventStateChanged")]
+#[derive(Clone)]
+pub struct PyConnectionEventStateChanged {
+    #[pyo3(get)]
+    connection_id: PyConnectionId,
+    #[pyo3(get)]
+    new_state: String,
+}
+
+#[pymethods]
+impl PyConnectionEventStateChanged {
+    #[new]
+    fn new(connection_id: PyConnectionId, new_state: String) -> Self {
+        PyConnectionEventStateChanged {
+            connection_id,
+            new_state,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ConnectionEventStateChanged(connection_id={:?}, new_state={})",
+            self.connection_id.0, self.new_state
+        )
+    }
+}
+
+// Helper function to convert Rust ConnectionEvent to appropriate Python subclass
+pub(crate) fn connection_event_to_py(
+    py: Python<'_>,
+    event: &samod_core::network::ConnectionEvent,
+) -> PyResult<PyObject> {
+    match event {
+        samod_core::network::ConnectionEvent::HandshakeCompleted {
+            connection_id,
+            peer_info,
+        } => Py::new(
+            py,
+            PyConnectionEventHandshakeCompleted {
+                connection_id: PyConnectionId(*connection_id),
+                peer_info: PyPeerInfo {
+                    inner: peer_info.clone(),
+                },
+            },
+        )
+        .map(|obj| obj.into()),
+        samod_core::network::ConnectionEvent::ConnectionFailed {
+            connection_id,
+            error,
+        } => Py::new(
+            py,
+            PyConnectionEventConnectionFailed {
+                connection_id: PyConnectionId(*connection_id),
+                error: error.clone(),
+            },
+        )
+        .map(|obj| obj.into()),
+        samod_core::network::ConnectionEvent::StateChanged {
+            connection_id,
+            new_state,
+        } => {
+            Py::new(
+                py,
+                PyConnectionEventStateChanged {
+                    connection_id: PyConnectionId(*connection_id),
+                    new_state: format!("{:?}", new_state), // Convert ConnectionInfo to string
+                },
+            )
+            .map(|obj| obj.into())
+        }
+    }
+}
+
+// ===== Hub Results =====
+
+/// Wrapper for samod_core::actors::hub::HubResults
+///
+/// Contains the results of processing a Hub event, including new IO tasks
+/// and completed commands.
+#[pyclass(name = "HubResults")]
+#[derive(Clone)]
+pub struct PyHubResults {
+    pub(crate) inner: samod_core::actors::hub::HubResults,
+}
+
+#[pymethods]
+impl PyHubResults {
+    /// Get new IO tasks that need to be executed
+    #[getter]
+    fn new_tasks<'py>(&self, py: Python<'py>) -> PyResult<Vec<Py<PyIoTask>>> {
+        self.inner
+            .new_tasks
+            .iter()
+            .map(|task| {
+                let py_task = PyIoTask::from(task.clone());
+                Py::new(py, py_task)
+            })
+            .collect()
+    }
+
+    /// Get completed commands
+    ///
+    /// Returns a dict mapping CommandId to CommandResult.
+    #[getter]
+    fn completed_commands<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
+        let dict = pyo3::types::PyDict::new(py);
+        for (cmd_id, result) in &self.inner.completed_commands {
+            dict.set_item(PyCommandId(*cmd_id), command_result_to_py(py, result)?)?;
+        }
+        Ok(dict)
+    }
+
+    /// Get requests to spawn new document actors
+    #[getter]
+    fn spawn_actors(&self) -> Vec<PySpawnArgs> {
+        self.inner
+            .spawn_actors
+            .iter()
+            .map(|args| PySpawnArgs::from(args.clone()))
+            .collect()
+    }
+
+    /// Get messages to send to document actors
+    ///
+    /// Returns a list of (DocumentActorId, HubToDocMsg) tuples.
+    #[getter]
+    fn actor_messages(&self) -> Vec<(PyDocumentActorId, PyHubToDocMsg)> {
+        self.inner
+            .actor_messages
+            .iter()
+            .map(|(id, msg)| (PyDocumentActorId(*id), PyHubToDocMsg::from(msg.clone())))
+            .collect()
+    }
+
+    /// Get connection events emitted during processing
+    #[getter]
+    fn connection_events<'py>(&self, py: Python<'py>) -> PyResult<Vec<PyObject>> {
+        self.inner
+            .connection_events
+            .iter()
+            .map(|event| connection_event_to_py(py, event))
+            .collect()
+    }
+
+    /// Check if the hub is stopped
+    #[getter]
+    fn stopped(&self) -> bool {
+        self.inner.stopped
+    }
+
+    fn __repr__(&self) -> String {
+        format!("HubResults(stopped={})", self.inner.stopped)
+    }
+}
+
+impl PyHubResults {
+    pub(crate) fn from_rust(
+        _py: Python<'_>,
+        results: samod_core::actors::hub::HubResults,
+    ) -> PyResult<Self> {
+        Ok(PyHubResults { inner: results })
+    }
+}

--- a/rust/src/repo/io.rs
+++ b/rust/src/repo/io.rs
@@ -1,0 +1,919 @@
+//! IO infrastructure for sans-IO pattern
+//!
+//! This module contains types for the sans-IO task/result pattern used throughout
+//! the repo implementation, including IoTaskId, IoTask, IoResult, action types,
+//! payload types, and IO result variant types.
+
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use samod_core::actors::document::io::{DocumentIoResult, DocumentIoTask};
+use samod_core::actors::hub::io::{HubIoAction, HubIoResult};
+
+use super::storage::{
+    PyStorageResult, PyStorageTaskDelete, PyStorageTaskLoad, PyStorageTaskLoadRange,
+    PyStorageTaskPut,
+};
+use super::types::{PyConnectionId, PyPeerId};
+
+/// Wrapper for samod_core::io::IoTaskId
+///
+/// Represents a unique identifier for an IO task.
+#[pyclass(name = "IoTaskId")]
+#[derive(Clone, Copy)]
+pub struct PyIoTaskId(pub(crate) samod_core::io::IoTaskId);
+
+#[pymethods]
+impl PyIoTaskId {
+    /// Create an IoTaskId from a u32
+    #[staticmethod]
+    fn from_u32(id: u32) -> Self {
+        PyIoTaskId(samod_core::io::IoTaskId::from(id))
+    }
+
+    /// Get the u32 representation of this IoTaskId
+    fn to_u32(&self) -> u32 {
+        self.0.into()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("IoTaskId({})", u32::from(self.0))
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        format!("{}", u32::from(self.0))
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        u32::from(self.0) as u64
+    }
+}
+
+// ===== Action Classes =====
+
+/// Action for storage operations
+///
+/// This is a wrapper that holds one of the StorageTask subclasses.
+/// Use isinstance() to determine which task type it contains.
+#[pyclass(name = "StorageTaskAction")]
+pub struct PyStorageTaskAction {
+    #[pyo3(get)]
+    pub task: PyObject, // One of: StorageTaskLoad, StorageTaskLoadRange, StorageTaskPut, StorageTaskDelete
+}
+
+impl Clone for PyStorageTaskAction {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| PyStorageTaskAction {
+            task: self.task.clone_ref(py),
+        })
+    }
+}
+
+#[pymethods]
+impl PyStorageTaskAction {
+    fn __repr__(&self) -> String {
+        Python::with_gil(|py| {
+            let task_repr = self.task.bind(py).repr().unwrap().to_string();
+            format!("StorageTaskAction({})", task_repr)
+        })
+    }
+}
+
+impl PyStorageTaskAction {
+    pub(crate) fn to_rust(&self) -> samod_core::io::StorageTask {
+        Python::with_gil(|py| {
+            let task = self.task.bind(py);
+
+            if let Ok(load) = task.extract::<PyStorageTaskLoad>() {
+                load.to_rust()
+            } else if let Ok(load_range) = task.extract::<PyStorageTaskLoadRange>() {
+                load_range.to_rust()
+            } else if let Ok(put) = task.extract::<PyStorageTaskPut>() {
+                put.to_rust()
+            } else if let Ok(delete) = task.extract::<PyStorageTaskDelete>() {
+                delete.to_rust()
+            } else {
+                panic!("Invalid StorageTask variant")
+            }
+        })
+    }
+}
+
+/// Action for sending messages over a connection
+#[pyclass(name = "SendAction")]
+#[derive(Clone)]
+pub struct PySendAction {
+    #[pyo3(get)]
+    pub connection_id: PyConnectionId,
+    message_bytes: Vec<u8>,
+}
+
+#[pymethods]
+impl PySendAction {
+    #[new]
+    fn new(connection_id: PyConnectionId, message: Vec<u8>) -> Self {
+        PySendAction {
+            connection_id,
+            message_bytes: message,
+        }
+    }
+
+    #[getter]
+    fn message<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new(py, &self.message_bytes)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SendAction(connection_id={}, message=<{} bytes>)",
+            u32::from(self.connection_id.0),
+            self.message_bytes.len()
+        )
+    }
+}
+
+/// Action for disconnecting a connection
+#[pyclass(name = "DisconnectAction")]
+#[derive(Clone)]
+pub struct PyDisconnectAction {
+    #[pyo3(get)]
+    pub connection_id: PyConnectionId,
+}
+
+#[pymethods]
+impl PyDisconnectAction {
+    #[new]
+    fn new(connection_id: PyConnectionId) -> Self {
+        PyDisconnectAction { connection_id }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DisconnectAction(connection_id={})",
+            u32::from(self.connection_id.0)
+        )
+    }
+}
+
+/// Action for checking document announce policy
+#[pyclass(name = "CheckAnnouncePolicyAction")]
+#[derive(Clone)]
+pub struct PyCheckAnnouncePolicyAction {
+    #[pyo3(get)]
+    pub peer_id: PyPeerId,
+}
+
+#[pymethods]
+impl PyCheckAnnouncePolicyAction {
+    #[new]
+    fn new(peer_id: PyPeerId) -> Self {
+        PyCheckAnnouncePolicyAction { peer_id }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CheckAnnouncePolicyAction(peer_id={})", self.peer_id.0)
+    }
+}
+
+// ===== Hub IO Result =====
+
+/// Send result for Hub IO operations
+///
+/// This variant has no associated data.
+#[pyclass(name = "HubIoResultSend")]
+#[derive(Clone)]
+pub struct PyHubIoResultSend;
+
+#[pymethods]
+impl PyHubIoResultSend {
+    #[new]
+    fn new() -> Self {
+        PyHubIoResultSend
+    }
+
+    fn __repr__(&self) -> String {
+        "HubIoResultSend()".to_string()
+    }
+}
+
+impl PyHubIoResultSend {
+    /// Convert to the underlying Rust enum variant
+    pub(crate) fn to_rust(&self) -> samod_core::actors::hub::io::HubIoResult {
+        samod_core::actors::hub::io::HubIoResult::Send
+    }
+}
+
+/// Disconnect result for Hub IO operations
+///
+/// This variant has no associated data.
+#[pyclass(name = "HubIoResultDisconnect")]
+#[derive(Clone)]
+pub struct PyHubIoResultDisconnect;
+
+#[pymethods]
+impl PyHubIoResultDisconnect {
+    #[new]
+    fn new() -> Self {
+        PyHubIoResultDisconnect
+    }
+
+    fn __repr__(&self) -> String {
+        "HubIoResultDisconnect()".to_string()
+    }
+}
+
+impl PyHubIoResultDisconnect {
+    /// Convert to the underlying Rust enum variant
+    pub(crate) fn to_rust(&self) -> samod_core::actors::hub::io::HubIoResult {
+        samod_core::actors::hub::io::HubIoResult::Disconnect
+    }
+}
+
+// ===== Document IO Result =====
+
+/// Storage result for Document IO operations
+#[pyclass(name = "DocumentIoResultStorage")]
+#[derive(Clone)]
+pub struct PyDocumentIoResultStorage {
+    #[pyo3(get)]
+    storage_result: PyStorageResult,
+}
+
+#[pymethods]
+impl PyDocumentIoResultStorage {
+    #[new]
+    fn new(storage_result: &PyStorageResult) -> Self {
+        PyDocumentIoResultStorage {
+            storage_result: storage_result.clone(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        "DocumentIoResultStorage(...)".to_string()
+    }
+}
+
+impl PyDocumentIoResultStorage {
+    /// Convert to the underlying Rust enum variant
+    pub(crate) fn to_rust(&self) -> samod_core::actors::document::io::DocumentIoResult {
+        samod_core::actors::document::io::DocumentIoResult::Storage(self.storage_result.0.clone())
+    }
+}
+
+/// CheckAnnouncePolicy result for Document IO operations
+#[pyclass(name = "DocumentIoResultCheckAnnouncePolicy")]
+#[derive(Clone)]
+pub struct PyDocumentIoResultCheckAnnouncePolicy {
+    #[pyo3(get)]
+    should_announce: bool,
+}
+
+#[pymethods]
+impl PyDocumentIoResultCheckAnnouncePolicy {
+    #[new]
+    fn new(should_announce: bool) -> Self {
+        PyDocumentIoResultCheckAnnouncePolicy { should_announce }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DocumentIoResultCheckAnnouncePolicy({})",
+            self.should_announce
+        )
+    }
+}
+
+impl PyDocumentIoResultCheckAnnouncePolicy {
+    /// Convert to the underlying Rust enum variant
+    pub(crate) fn to_rust(&self) -> samod_core::actors::document::io::DocumentIoResult {
+        samod_core::actors::document::io::DocumentIoResult::CheckAnnouncePolicy(
+            self.should_announce,
+        )
+    }
+}
+
+// ===== IoTask =====
+
+/// Wrapper for samod_core::io::IoTask<Action>
+///
+/// Represents an IO task with an ID and an action. The action can be one of:
+/// - StorageTaskAction
+/// - SendAction
+/// - DisconnectAction
+/// - CheckAnnouncePolicyAction
+#[pyclass(name = "IoTask")]
+pub struct PyIoTask {
+    #[pyo3(get)]
+    task_id: PyIoTaskId,
+    #[pyo3(get)]
+    action: PyObject,
+}
+
+#[pymethods]
+impl PyIoTask {
+    fn __repr__(&self) -> String {
+        Python::with_gil(|py| {
+            let action_repr = self.action.bind(py).repr().unwrap().to_string();
+            format!(
+                "IoTask(task_id={}, action={})",
+                u32::from(self.task_id.0),
+                action_repr
+            )
+        })
+    }
+}
+
+// Internal conversion from Rust IoTask<StorageTask> to Python
+impl From<samod_core::io::IoTask<samod_core::io::StorageTask>> for PyIoTask {
+    fn from(task: samod_core::io::IoTask<samod_core::io::StorageTask>) -> Self {
+        Python::with_gil(|py| {
+            // Convert the Rust StorageTask enum to the appropriate Python subclass
+            let task_obj: PyObject = match &task.action {
+                samod_core::io::StorageTask::Load { key } => Py::new(
+                    py,
+                    PyStorageTaskLoad {
+                        key: super::storage::PyStorageKey(key.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::LoadRange { prefix } => Py::new(
+                    py,
+                    PyStorageTaskLoadRange {
+                        prefix: super::storage::PyStorageKey(prefix.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::Put { key, value } => Py::new(
+                    py,
+                    PyStorageTaskPut {
+                        key: super::storage::PyStorageKey(key.clone()),
+                        value: value.clone(),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::Delete { key } => Py::new(
+                    py,
+                    PyStorageTaskDelete {
+                        key: super::storage::PyStorageKey(key.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+            };
+
+            let action = PyStorageTaskAction { task: task_obj };
+            PyIoTask {
+                task_id: PyIoTaskId(task.task_id),
+                action: Py::new(py, action).unwrap().into(),
+            }
+        })
+    }
+}
+
+// Internal conversion from Rust IoTask<HubIoAction> to Python
+impl From<samod_core::io::IoTask<HubIoAction>> for PyIoTask {
+    fn from(task: samod_core::io::IoTask<HubIoAction>) -> Self {
+        Python::with_gil(|py| {
+            let action: PyObject = match task.action {
+                HubIoAction::Send { connection_id, msg } => Py::new(
+                    py,
+                    PySendAction {
+                        connection_id: PyConnectionId(connection_id),
+                        message_bytes: msg,
+                    },
+                )
+                .unwrap()
+                .into(),
+                HubIoAction::Disconnect { connection_id } => Py::new(
+                    py,
+                    PyDisconnectAction {
+                        connection_id: PyConnectionId(connection_id),
+                    },
+                )
+                .unwrap()
+                .into(),
+            };
+            PyIoTask {
+                task_id: PyIoTaskId(task.task_id),
+                action,
+            }
+        })
+    }
+}
+
+// Internal conversion from Rust IoTask<DocumentIoTask> to Python
+impl From<samod_core::io::IoTask<DocumentIoTask>> for PyIoTask {
+    fn from(task: samod_core::io::IoTask<DocumentIoTask>) -> Self {
+        Python::with_gil(|py| {
+            let action: PyObject = match task.action {
+                DocumentIoTask::Storage(storage_task) => {
+                    // Convert the Rust StorageTask enum to the appropriate Python subclass
+                    let task_obj: PyObject = match &storage_task {
+                        samod_core::io::StorageTask::Load { key } => Py::new(
+                            py,
+                            PyStorageTaskLoad {
+                                key: super::storage::PyStorageKey(key.clone()),
+                            },
+                        )
+                        .unwrap()
+                        .into(),
+                        samod_core::io::StorageTask::LoadRange { prefix } => Py::new(
+                            py,
+                            PyStorageTaskLoadRange {
+                                prefix: super::storage::PyStorageKey(prefix.clone()),
+                            },
+                        )
+                        .unwrap()
+                        .into(),
+                        samod_core::io::StorageTask::Put { key, value } => Py::new(
+                            py,
+                            PyStorageTaskPut {
+                                key: super::storage::PyStorageKey(key.clone()),
+                                value: value.clone(),
+                            },
+                        )
+                        .unwrap()
+                        .into(),
+                        samod_core::io::StorageTask::Delete { key } => Py::new(
+                            py,
+                            PyStorageTaskDelete {
+                                key: super::storage::PyStorageKey(key.clone()),
+                            },
+                        )
+                        .unwrap()
+                        .into(),
+                    };
+
+                    Py::new(py, PyStorageTaskAction { task: task_obj })
+                        .unwrap()
+                        .into()
+                }
+                DocumentIoTask::CheckAnnouncePolicy { peer_id } => Py::new(
+                    py,
+                    PyCheckAnnouncePolicyAction {
+                        peer_id: PyPeerId(peer_id),
+                    },
+                )
+                .unwrap()
+                .into(),
+            };
+            PyIoTask {
+                task_id: PyIoTaskId(task.task_id),
+                action,
+            }
+        })
+    }
+}
+
+// Helper to convert a reference to DocumentIoTask to PyIoTask
+pub(crate) fn document_io_task_ref_to_py(
+    py: Python<'_>,
+    task_id: samod_core::io::IoTaskId,
+    task: &DocumentIoTask,
+) -> PyIoTask {
+    let action: PyObject = match task {
+        DocumentIoTask::Storage(storage_task) => {
+            let task_obj: PyObject = match storage_task {
+                samod_core::io::StorageTask::Load { key } => Py::new(
+                    py,
+                    PyStorageTaskLoad {
+                        key: super::storage::PyStorageKey(key.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::LoadRange { prefix } => Py::new(
+                    py,
+                    PyStorageTaskLoadRange {
+                        prefix: super::storage::PyStorageKey(prefix.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::Put { key, value } => Py::new(
+                    py,
+                    PyStorageTaskPut {
+                        key: super::storage::PyStorageKey(key.clone()),
+                        value: value.clone(),
+                    },
+                )
+                .unwrap()
+                .into(),
+                samod_core::io::StorageTask::Delete { key } => Py::new(
+                    py,
+                    PyStorageTaskDelete {
+                        key: super::storage::PyStorageKey(key.clone()),
+                    },
+                )
+                .unwrap()
+                .into(),
+            };
+            Py::new(py, PyStorageTaskAction { task: task_obj })
+                .unwrap()
+                .into()
+        }
+        DocumentIoTask::CheckAnnouncePolicy { peer_id } => Py::new(
+            py,
+            PyCheckAnnouncePolicyAction {
+                peer_id: PyPeerId(peer_id.clone()),
+            },
+        )
+        .unwrap()
+        .into(),
+    };
+    PyIoTask {
+        task_id: PyIoTaskId(task_id),
+        action,
+    }
+}
+
+// ===== Payload Classes =====
+
+/// Payload for storage operation results
+#[pyclass(name = "StorageResultPayload")]
+pub struct PyStorageResultPayload {
+    pub(crate) result: std::sync::Mutex<Option<samod_core::io::StorageResult>>,
+}
+
+#[pymethods]
+impl PyStorageResultPayload {
+    fn __repr__(&self) -> String {
+        "StorageResultPayload(<StorageResult>)".to_string()
+    }
+}
+
+impl PyStorageResultPayload {
+    /// Take the storage result (consumes it, can only be called once)
+    pub(crate) fn take_result(&self) -> PyResult<PyStorageResult> {
+        let mut guard = self.result.lock().map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("Lock error: {}", e))
+        })?;
+        if let Some(result) = guard.take() {
+            Ok(PyStorageResult(result))
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "StorageResultPayload has already been consumed",
+            ))
+        }
+    }
+}
+
+/// Payload for check announce policy results
+#[pyclass(name = "CheckAnnouncePolicyResultPayload")]
+#[derive(Clone)]
+pub struct PyCheckAnnouncePolicyResultPayload {
+    #[pyo3(get)]
+    pub should_announce: bool,
+}
+
+#[pymethods]
+impl PyCheckAnnouncePolicyResultPayload {
+    #[new]
+    fn new(should_announce: bool) -> Self {
+        PyCheckAnnouncePolicyResultPayload { should_announce }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CheckAnnouncePolicyResultPayload(should_announce={})",
+            self.should_announce
+        )
+    }
+}
+
+/// Payload for send operation results (success indicator)
+#[pyclass(name = "SendResultPayload")]
+#[derive(Clone)]
+pub struct PySendResultPayload;
+
+#[pymethods]
+impl PySendResultPayload {
+    #[new]
+    fn new() -> Self {
+        PySendResultPayload
+    }
+
+    fn __repr__(&self) -> String {
+        "SendResultPayload()".to_string()
+    }
+}
+
+/// Payload for disconnect operation results (success indicator)
+#[pyclass(name = "DisconnectResultPayload")]
+#[derive(Clone)]
+pub struct PyDisconnectResultPayload;
+
+#[pymethods]
+impl PyDisconnectResultPayload {
+    #[new]
+    fn new() -> Self {
+        PyDisconnectResultPayload
+    }
+
+    fn __repr__(&self) -> String {
+        "DisconnectResultPayload()".to_string()
+    }
+}
+
+// ===== IoResult =====
+
+/// Wrapper for samod_core::io::IoResult<Payload>
+///
+/// Represents the result of an IO task with an ID and a payload. The payload can be one of:
+/// - StorageResultPayload
+/// - CheckAnnouncePolicyResultPayload
+/// - SendResultPayload
+/// - DisconnectResultPayload
+#[pyclass(name = "IoResult")]
+pub struct PyIoResult {
+    #[pyo3(get)]
+    pub(crate) task_id: PyIoTaskId,
+    #[pyo3(get)]
+    pub(crate) payload: PyObject,
+}
+
+impl Clone for PyIoResult {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| PyIoResult {
+            task_id: self.task_id,
+            payload: self.payload.clone_ref(py),
+        })
+    }
+}
+
+#[pymethods]
+impl PyIoResult {
+    /// Create a new IoResult with a task ID and StorageResult payload
+    ///
+    /// This is used when bridging between Python storage adapters and Rust actors.
+    /// After executing a storage task via Python's Storage protocol, call this method
+    /// to create an IoResult that can be fed back to the loader/hub/document actors.
+    #[staticmethod]
+    fn from_storage_result(
+        task_id: PyIoTaskId,
+        storage_result: &PyStorageResult,
+    ) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            let payload = PyStorageResultPayload {
+                result: std::sync::Mutex::new(Some(storage_result.0.clone())),
+            };
+            Ok(PyIoResult {
+                task_id,
+                payload: Py::new(py, payload)?.into(),
+            })
+        })
+    }
+
+    /// Create a new IoResult with a task ID and HubIoResult payload
+    ///
+    /// This is used when providing Hub IO results (Send or Disconnect).
+    ///
+    /// Args:
+    ///     task_id: The IO task ID
+    ///     hub_result: The HubIoResultSend or HubIoResultDisconnect
+    #[staticmethod]
+    fn from_hub_result<'py>(task_id: PyIoTaskId, hub_result: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            let payload: PyObject = if hub_result.is_instance_of::<PyHubIoResultSend>() {
+                Py::new(py, PySendResultPayload)?.into()
+            } else if hub_result.is_instance_of::<PyHubIoResultDisconnect>() {
+                Py::new(py, PyDisconnectResultPayload)?.into()
+            } else {
+                return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "Expected HubIoResultSend or HubIoResultDisconnect",
+                ));
+            };
+            Ok(PyIoResult { task_id, payload })
+        })
+    }
+
+    /// Create a new IoResult with a task ID and DocumentIoResult payload
+    ///
+    /// This is used when providing Document IO results.
+    ///
+    /// Args:
+    ///     task_id: The IO task ID
+    ///     doc_result: The DocumentIoResultStorage or DocumentIoResultCheckAnnouncePolicy
+    #[staticmethod]
+    fn from_document_result<'py>(
+        task_id: PyIoTaskId,
+        doc_result: &Bound<'py, PyAny>,
+    ) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            let payload: PyObject =
+                if let Ok(storage) = doc_result.extract::<PyDocumentIoResultStorage>() {
+                    Py::new(
+                        py,
+                        PyStorageResultPayload {
+                            result: std::sync::Mutex::new(Some(storage.storage_result.0.clone())),
+                        },
+                    )?
+                    .into()
+                } else if let Ok(announce) =
+                    doc_result.extract::<PyDocumentIoResultCheckAnnouncePolicy>()
+                {
+                    Py::new(
+                        py,
+                        PyCheckAnnouncePolicyResultPayload {
+                            should_announce: announce.should_announce,
+                        },
+                    )?
+                    .into()
+                } else {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Expected DocumentIoResultStorage or DocumentIoResultCheckAnnouncePolicy",
+                    ));
+                };
+            Ok(PyIoResult { task_id, payload })
+        })
+    }
+
+    /// Create an IoResult for a successful send operation
+    #[staticmethod]
+    fn from_send_result(task_id: PyIoTaskId) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            Ok(PyIoResult {
+                task_id,
+                payload: Py::new(py, PySendResultPayload)?.into(),
+            })
+        })
+    }
+
+    /// Create an IoResult for a successful disconnect operation
+    #[staticmethod]
+    fn from_disconnect_result(task_id: PyIoTaskId) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            Ok(PyIoResult {
+                task_id,
+                payload: Py::new(py, PyDisconnectResultPayload)?.into(),
+            })
+        })
+    }
+
+    /// Create an IoResult for a check announce policy operation
+    #[staticmethod]
+    fn from_check_announce_policy_result(
+        task_id: PyIoTaskId,
+        should_announce: bool,
+    ) -> PyResult<Self> {
+        Python::with_gil(|py| {
+            Ok(PyIoResult {
+                task_id,
+                payload: Py::new(py, PyCheckAnnouncePolicyResultPayload { should_announce })?
+                    .into(),
+            })
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        Python::with_gil(|py| {
+            let payload_repr = self.payload.bind(py).repr().unwrap().to_string();
+            format!(
+                "IoResult(task_id={}, payload={})",
+                u32::from(self.task_id.0),
+                payload_repr
+            )
+        })
+    }
+}
+
+// Internal conversion methods
+
+impl PyIoResult {
+    /// Convert PyIoResult back to Rust IoResult<DocumentIoResult>
+    ///
+    /// This is used when feeding IO results back to document actors.
+    pub(crate) fn to_document_io_result(
+        &self,
+    ) -> PyResult<samod_core::io::IoResult<DocumentIoResult>> {
+        Python::with_gil(|py| {
+            let payload_obj = self.payload.bind(py);
+
+            // Try to extract the payload as different types
+            let payload =
+                if let Ok(storage_payload) = payload_obj.extract::<Py<PyStorageResultPayload>>() {
+                    // Extract the storage result from the payload
+                    let storage_result = storage_payload.borrow(py).take_result()?;
+                    DocumentIoResult::Storage(storage_result.0)
+                } else if let Ok(announce_payload) =
+                    payload_obj.extract::<PyCheckAnnouncePolicyResultPayload>()
+                {
+                    DocumentIoResult::CheckAnnouncePolicy(announce_payload.should_announce)
+                } else {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Expected StorageResultPayload or CheckAnnouncePolicyResultPayload",
+                    ));
+                };
+
+            Ok(samod_core::io::IoResult {
+                task_id: self.task_id.0,
+                payload,
+            })
+        })
+    }
+
+    /// Convert PyIoResult back to Rust IoResult<HubIoResult>
+    ///
+    /// This is used when feeding IO results back to the Hub.
+    pub(crate) fn to_hub_io_result(&self) -> PyResult<samod_core::io::IoResult<HubIoResult>> {
+        Python::with_gil(|py| {
+            let payload_obj = self.payload.bind(py);
+
+            // Try to extract the payload as different types
+            let payload =
+                if let Ok(_send_payload) = payload_obj.extract::<Py<PySendResultPayload>>() {
+                    HubIoResult::Send
+                } else if let Ok(_disconnect_payload) =
+                    payload_obj.extract::<Py<PyDisconnectResultPayload>>()
+                {
+                    HubIoResult::Disconnect
+                } else {
+                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                        "Expected SendResultPayload or DisconnectResultPayload",
+                    ));
+                };
+
+            Ok(samod_core::io::IoResult {
+                task_id: self.task_id.0,
+                payload,
+            })
+        })
+    }
+
+    /// Convert PyIoResult to core IoResult for HubEvent.io_complete()
+    ///
+    /// This auto-detects the payload type and converts appropriately.
+    pub(crate) fn to_core(&self) -> samod_core::io::IoResult<HubIoResult> {
+        // Try to convert as Hub IO result first
+        self.to_hub_io_result()
+            .expect("Failed to convert PyIoResult to core IoResult")
+    }
+}
+
+// Internal conversion from Rust IoResult<StorageResult> to Python
+impl From<samod_core::io::IoResult<samod_core::io::StorageResult>> for PyIoResult {
+    fn from(result: samod_core::io::IoResult<samod_core::io::StorageResult>) -> Self {
+        Python::with_gil(|py| {
+            let payload = PyStorageResultPayload {
+                result: std::sync::Mutex::new(Some(result.payload)),
+            };
+            PyIoResult {
+                task_id: PyIoTaskId(result.task_id),
+                payload: Py::new(py, payload).unwrap().into(),
+            }
+        })
+    }
+}
+
+// Internal conversion from Rust IoResult<HubIoResult> to Python
+impl From<samod_core::io::IoResult<HubIoResult>> for PyIoResult {
+    fn from(result: samod_core::io::IoResult<HubIoResult>) -> Self {
+        Python::with_gil(|py| {
+            let payload: PyObject = match result.payload {
+                HubIoResult::Send => Py::new(py, PySendResultPayload).unwrap().into(),
+                HubIoResult::Disconnect => Py::new(py, PyDisconnectResultPayload).unwrap().into(),
+            };
+            PyIoResult {
+                task_id: PyIoTaskId(result.task_id),
+                payload,
+            }
+        })
+    }
+}
+
+// Internal conversion from Rust IoResult<DocumentIoResult> to Python
+impl From<samod_core::io::IoResult<DocumentIoResult>> for PyIoResult {
+    fn from(result: samod_core::io::IoResult<DocumentIoResult>) -> Self {
+        Python::with_gil(|py| {
+            let payload: PyObject = match result.payload {
+                DocumentIoResult::Storage(storage_result) => Py::new(
+                    py,
+                    PyStorageResultPayload {
+                        result: std::sync::Mutex::new(Some(storage_result)),
+                    },
+                )
+                .unwrap()
+                .into(),
+                DocumentIoResult::CheckAnnouncePolicy(should_announce) => {
+                    Py::new(py, PyCheckAnnouncePolicyResultPayload { should_announce })
+                        .unwrap()
+                        .into()
+                }
+            };
+            PyIoResult {
+                task_id: PyIoTaskId(result.task_id),
+                payload,
+            }
+        })
+    }
+}

--- a/rust/src/repo/loader.rs
+++ b/rust/src/repo/loader.rs
@@ -1,0 +1,186 @@
+//! Loader types for repository initialization
+//!
+//! This module contains types for the SamodLoader and its state machine,
+//! which handles loading repository state from storage.
+
+use pyo3::prelude::*;
+
+use super::types::PyPeerId;
+use super::io::{PyIoTask, PyIoResult, PyStorageResultPayload};
+use super::hub::PyHub;
+
+/// LoaderState variant indicating IO tasks need to be executed
+///
+/// This is a consume-once type - the tasks can only be retrieved once.
+#[pyclass(name = "LoaderStateNeedIo")]
+pub struct PyLoaderStateNeedIo {
+    tasks: std::sync::Mutex<Option<Vec<Py<PyIoTask>>>>,
+}
+
+#[pymethods]
+impl PyLoaderStateNeedIo {
+    /// Get the IO tasks (consume-once)
+    ///
+    /// This method consumes the tasks - it can only be called once.
+    /// Subsequent calls will raise an error.
+    #[getter]
+    fn tasks(&self, py: Python<'_>) -> PyResult<Py<pyo3::types::PyList>> {
+        let mut guard = self.tasks.lock().unwrap();
+        if let Some(tasks) = guard.take() {
+            let py_list = pyo3::types::PyList::empty(py);
+            for task in tasks {
+                py_list.append(task)?;
+            }
+            Ok(py_list.into())
+        } else {
+            Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "tasks have already been consumed"
+            ))
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        let guard = self.tasks.lock().unwrap();
+        if let Some(tasks) = guard.as_ref() {
+            format!("LoaderStateNeedIo(tasks={})", tasks.len())
+        } else {
+            "LoaderStateNeedIo(<consumed>)".to_string()
+        }
+    }
+}
+
+/// LoaderState variant indicating loading is complete and Hub is ready
+///
+/// This is a consume-once type - the hub can only be retrieved once.
+#[pyclass(name = "LoaderStateLoaded")]
+pub struct PyLoaderStateLoaded {
+    hub: std::sync::Mutex<Option<Py<PyHub>>>,
+}
+
+#[pymethods]
+impl PyLoaderStateLoaded {
+    /// Get the Hub (consume-once)
+    ///
+    /// This method consumes the hub - it can only be called once.
+    /// Subsequent calls will raise an error.
+    #[getter]
+    fn hub(&self) -> PyResult<Py<PyHub>> {
+        let mut guard = self.hub.lock().unwrap();
+        guard.take()
+            .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "hub has already been consumed"
+            ))
+    }
+
+    fn __repr__(&self) -> String {
+        let guard = self.hub.lock().unwrap();
+        if guard.is_some() {
+            "LoaderStateLoaded(hub=...)".to_string()
+        } else {
+            "LoaderStateLoaded(<consumed>)".to_string()
+        }
+    }
+}
+
+/// Wrapper for samod_core::SamodLoader
+///
+/// The loader is responsible for initializing the repository by loading
+/// initial state from storage. It uses the sans-IO pattern: it produces
+/// IO tasks that must be executed by the caller, and then the results
+/// are fed back to progress the loading process.
+///
+/// Usage:
+/// 1. Create a loader with SamodLoader(peer_id)
+/// 2. Call step() to get the current state
+/// 3. If NeedIo, execute the IO tasks and call provide_io_result() for each
+/// 4. Call step() again
+/// 5. Repeat until Loaded
+#[pyclass(name = "SamodLoader")]
+pub struct PySamodLoader {
+    inner: std::sync::Arc<std::sync::Mutex<samod_core::SamodLoader>>,
+}
+
+#[pymethods]
+impl PySamodLoader {
+    /// Create a new SamodLoader with the given peer ID
+    #[new]
+    fn new(peer_id: PyPeerId) -> PyResult<Self> {
+        let loader = samod_core::SamodLoader::new(peer_id.0);
+        Ok(PySamodLoader {
+            inner: std::sync::Arc::new(std::sync::Mutex::new(loader)),
+        })
+    }
+
+    /// Step the loader state machine forward
+    ///
+    /// Args:
+    ///     now: Current Unix timestamp in seconds (float)
+    ///
+    /// Returns:
+    ///     Either LoaderStateNeedIo (with tasks to execute) or LoaderStateLoaded (with the Hub)
+    fn step(&self, now: f64) -> PyResult<PyObject> {
+        let mut guard = self.inner.lock().unwrap();
+        let mut rng = rand::rng();
+        let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
+
+        Python::with_gil(|py| {
+            match guard.step(&mut rng, timestamp) {
+                samod_core::LoaderState::NeedIo(tasks) => {
+                    let py_tasks: Vec<Py<PyIoTask>> = tasks.into_iter()
+                        .map(|task| {
+                            let py_task: PyIoTask = task.into();
+                            Py::new(py, py_task).unwrap()
+                        })
+                        .collect();
+                    let state = PyLoaderStateNeedIo {
+                        tasks: std::sync::Mutex::new(Some(py_tasks)),
+                    };
+                    Ok(Py::new(py, state)?.into())
+                }
+                samod_core::LoaderState::Loaded(hub) => {
+                    let py_hub = Py::new(py, PyHub {
+                        inner: std::sync::Arc::new(std::sync::Mutex::new(*hub)),
+                    })?;
+                    let state = PyLoaderStateLoaded {
+                        hub: std::sync::Mutex::new(Some(py_hub)),
+                    };
+                    Ok(Py::new(py, state)?.into())
+                }
+            }
+        })
+    }
+
+    /// Provide the result of an IO operation
+    ///
+    /// Call this method for each IO task that was returned by step().
+    ///
+    /// Args:
+    ///     io_result: The result of executing an IoTask
+    fn provide_io_result(&self, io_result: &PyIoResult) -> PyResult<()> {
+        let mut guard = self.inner.lock().unwrap();
+
+        // Extract the payload from PyIoResult
+        Python::with_gil(|py| {
+            let payload = io_result.payload.bind(py);
+
+            // Check if it's a StorageResultPayload
+            if let Ok(storage_payload) = payload.downcast::<PyStorageResultPayload>() {
+                let storage_result = storage_payload.borrow().take_result()?;
+                let rust_result = samod_core::io::IoResult {
+                    task_id: io_result.task_id.0,
+                    payload: storage_result.0,
+                };
+                guard.provide_io_result(rust_result);
+                Ok(())
+            } else {
+                Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+                    "Expected StorageResultPayload for loader"
+                ))
+            }
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "SamodLoader(...)".to_string()
+    }
+}

--- a/rust/src/repo/loader.rs
+++ b/rust/src/repo/loader.rs
@@ -5,9 +5,9 @@
 
 use pyo3::prelude::*;
 
-use super::types::PyPeerId;
-use super::io::{PyIoTask, PyIoResult, PyStorageResultPayload};
 use super::hub::PyHub;
+use super::io::{PyIoResult, PyIoTask, PyStorageResultPayload};
+use super::types::PyPeerId;
 
 /// LoaderState variant indicating IO tasks need to be executed
 ///
@@ -34,7 +34,7 @@ impl PyLoaderStateNeedIo {
             Ok(py_list.into())
         } else {
             Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "tasks have already been consumed"
+                "tasks have already been consumed",
             ))
         }
     }
@@ -66,10 +66,9 @@ impl PyLoaderStateLoaded {
     #[getter]
     fn hub(&self) -> PyResult<Py<PyHub>> {
         let mut guard = self.hub.lock().unwrap();
-        guard.take()
-            .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "hub has already been consumed"
-            ))
+        guard.take().ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("hub has already been consumed")
+        })
     }
 
     fn __repr__(&self) -> String {
@@ -123,29 +122,31 @@ impl PySamodLoader {
         let mut rng = rand::rng();
         let timestamp = samod_core::UnixTimestamp::from_millis((now * 1000.0) as u128);
 
-        Python::with_gil(|py| {
-            match guard.step(&mut rng, timestamp) {
-                samod_core::LoaderState::NeedIo(tasks) => {
-                    let py_tasks: Vec<Py<PyIoTask>> = tasks.into_iter()
-                        .map(|task| {
-                            let py_task: PyIoTask = task.into();
-                            Py::new(py, py_task).unwrap()
-                        })
-                        .collect();
-                    let state = PyLoaderStateNeedIo {
-                        tasks: std::sync::Mutex::new(Some(py_tasks)),
-                    };
-                    Ok(Py::new(py, state)?.into())
-                }
-                samod_core::LoaderState::Loaded(hub) => {
-                    let py_hub = Py::new(py, PyHub {
+        Python::with_gil(|py| match guard.step(&mut rng, timestamp) {
+            samod_core::LoaderState::NeedIo(tasks) => {
+                let py_tasks: Vec<Py<PyIoTask>> = tasks
+                    .into_iter()
+                    .map(|task| {
+                        let py_task: PyIoTask = task.into();
+                        Py::new(py, py_task).unwrap()
+                    })
+                    .collect();
+                let state = PyLoaderStateNeedIo {
+                    tasks: std::sync::Mutex::new(Some(py_tasks)),
+                };
+                Ok(Py::new(py, state)?.into())
+            }
+            samod_core::LoaderState::Loaded(hub) => {
+                let py_hub = Py::new(
+                    py,
+                    PyHub {
                         inner: std::sync::Arc::new(std::sync::Mutex::new(*hub)),
-                    })?;
-                    let state = PyLoaderStateLoaded {
-                        hub: std::sync::Mutex::new(Some(py_hub)),
-                    };
-                    Ok(Py::new(py, state)?.into())
-                }
+                    },
+                )?;
+                let state = PyLoaderStateLoaded {
+                    hub: std::sync::Mutex::new(Some(py_hub)),
+                };
+                Ok(Py::new(py, state)?.into())
             }
         })
     }
@@ -174,7 +175,7 @@ impl PySamodLoader {
                 Ok(())
             } else {
                 Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                    "Expected StorageResultPayload for loader"
+                    "Expected StorageResultPayload for loader",
                 ))
             }
         })

--- a/rust/src/repo/mod.rs
+++ b/rust/src/repo/mod.rs
@@ -1,0 +1,119 @@
+//! Python bindings for samod-core
+//!
+//! This module provides PyO3 wrappers for samod-core types, exposing them to Python
+//! without the "Py" prefix (e.g., `PeerId` in Python, `PyPeerId` in Rust).
+
+use pyo3::prelude::*;
+
+// Module declarations
+pub mod types;
+pub mod storage;
+pub mod io;
+pub mod loader;
+pub mod commands;
+pub mod hub_events;
+pub mod hub_results;
+pub mod document;
+pub mod hub;
+pub mod connection;
+
+// Re-export all public types
+pub use types::*;
+pub use storage::*;
+pub use io::*;
+pub use loader::*;
+pub use commands::*;
+pub use hub_events::*;
+pub use hub_results::*;
+pub use document::*;
+pub use hub::*;
+pub use connection::*;
+
+/// Register all repo types with the Python module
+pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Identity types
+    m.add_class::<PyPeerId>()?;
+    m.add_class::<PyStorageId>()?;
+    m.add_class::<PyConnectionId>()?;
+    m.add_class::<PyDocumentActorId>()?;
+    m.add_class::<PyDocumentId>()?;
+    m.add_class::<PyAutomergeUrl>()?;
+
+    // Storage types
+    m.add_class::<PyStorageKey>()?;
+    m.add_class::<PyStorageTaskLoad>()?;
+    m.add_class::<PyStorageTaskLoadRange>()?;
+    m.add_class::<PyStorageTaskPut>()?;
+    m.add_class::<PyStorageTaskDelete>()?;
+    m.add_class::<PyStorageResult>()?;
+
+    // IO types
+    m.add_class::<PyIoTaskId>()?;
+
+    // Action classes
+    m.add_class::<PyStorageTaskAction>()?;
+    m.add_class::<PySendAction>()?;
+    m.add_class::<PyDisconnectAction>()?;
+    m.add_class::<PyCheckAnnouncePolicyAction>()?;
+
+    // Payload classes
+    m.add_class::<PyStorageResultPayload>()?;
+    m.add_class::<PyCheckAnnouncePolicyResultPayload>()?;
+    m.add_class::<PySendResultPayload>()?;
+    m.add_class::<PyDisconnectResultPayload>()?;
+
+    // IO Result types
+    m.add_class::<PyHubIoResultSend>()?;
+    m.add_class::<PyHubIoResultDisconnect>()?;
+    m.add_class::<PyDocumentIoResultStorage>()?;
+    m.add_class::<PyDocumentIoResultCheckAnnouncePolicy>()?;
+
+    // IoTask and IoResult
+    m.add_class::<PyIoTask>()?;
+    m.add_class::<PyIoResult>()?;
+
+    // Loader
+    m.add_class::<PyLoaderStateNeedIo>()?;
+    m.add_class::<PyLoaderStateLoaded>()?;
+    m.add_class::<PySamodLoader>()?;
+
+    // Commands
+    m.add_class::<PyCommandId>()?;
+    m.add_class::<PyDispatchedCommand>()?;
+    m.add_class::<PyCommandResultCreateConnection>()?;
+    m.add_class::<PyCommandResultDisconnectConnection>()?;
+    m.add_class::<PyCommandResultReceive>()?;
+    m.add_class::<PyCommandResultActorReady>()?;
+    m.add_class::<PyCommandResultCreateDocument>()?;
+    m.add_class::<PyCommandResultFindDocument>()?;
+
+    // Hub events
+    m.add_class::<PyPeerInfo>()?;
+    m.add_class::<PyConnDirection>()?;
+    m.add_class::<PyHubEvent>()?;
+
+    // Hub results
+    m.add_class::<PyConnectionEventHandshakeCompleted>()?;
+    m.add_class::<PyConnectionEventConnectionFailed>()?;
+    m.add_class::<PyConnectionEventStateChanged>()?;
+    m.add_class::<PyHubResults>()?;
+
+    // Document types
+    m.add_class::<PySpawnArgs>()?;
+    m.add_class::<PyHubToDocMsg>()?;
+    m.add_class::<PyDocToHubMsg>()?;
+    m.add_class::<PyDocActorResult>()?;
+    m.add_class::<PyDocumentActor>()?;
+
+    // Hub
+    m.add_class::<PyHub>()?;
+
+    // Connection info types
+    m.add_class::<PyConnectionState>()?;
+    m.add_class::<PyConnectionStateHandshaking>()?;
+    m.add_class::<PyConnectionStateConnected>()?;
+    m.add_class::<PyPeerDocState>()?;
+    m.add_class::<PyConnectionInfo>()?;
+
+    Ok(())
+}

--- a/rust/src/repo/mod.rs
+++ b/rust/src/repo/mod.rs
@@ -6,28 +6,28 @@
 use pyo3::prelude::*;
 
 // Module declarations
-pub mod types;
-pub mod storage;
-pub mod io;
-pub mod loader;
 pub mod commands;
-pub mod hub_events;
-pub mod hub_results;
+pub mod connection;
 pub mod document;
 pub mod hub;
-pub mod connection;
+pub mod hub_events;
+pub mod hub_results;
+pub mod io;
+pub mod loader;
+pub mod storage;
+pub mod types;
 
 // Re-export all public types
-pub use types::*;
-pub use storage::*;
-pub use io::*;
-pub use loader::*;
 pub use commands::*;
-pub use hub_events::*;
-pub use hub_results::*;
+pub use connection::*;
 pub use document::*;
 pub use hub::*;
-pub use connection::*;
+pub use hub_events::*;
+pub use hub_results::*;
+pub use io::*;
+pub use loader::*;
+pub use storage::*;
+pub use types::*;
 
 /// Register all repo types with the Python module
 pub fn register_types(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/rust/src/repo/storage.rs
+++ b/rust/src/repo/storage.rs
@@ -1,0 +1,281 @@
+//! Storage types and operations
+//!
+//! This module contains wrappers for storage-related types including StorageKey,
+//! StorageTask, and StorageResult.
+
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use std::collections::HashMap;
+
+/// Wrapper for samod_core::StorageKey
+///
+/// Represents a hierarchical key for storage operations. Storage keys are
+/// composed of string components that form a path-like structure.
+#[pyclass(name = "StorageKey")]
+#[derive(Clone)]
+pub struct PyStorageKey(pub(crate) samod_core::StorageKey);
+
+#[pymethods]
+impl PyStorageKey {
+    /// Create a StorageKey from a list of string parts
+    #[staticmethod]
+    fn from_parts(parts: Vec<String>) -> PyResult<Self> {
+        samod_core::StorageKey::from_parts(parts)
+            .map(PyStorageKey)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Get the parts of this StorageKey as a list of strings
+    fn to_parts(&self) -> Vec<String> {
+        self.0.clone().into_iter().collect()
+    }
+
+    /// String representation (parts joined with "/")
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("StorageKey(\"{}\")", self.0)
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.0.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+// ===== Storage Task Variants =====
+
+/// Load task - retrieve a single value by key
+#[pyclass(name = "StorageTaskLoad")]
+#[derive(Clone)]
+pub struct PyStorageTaskLoad {
+    #[pyo3(get)]
+    pub(crate) key: PyStorageKey,
+}
+
+#[pymethods]
+impl PyStorageTaskLoad {
+    #[new]
+    fn new(key: PyStorageKey) -> Self {
+        PyStorageTaskLoad { key }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("StorageTaskLoad(key={})", self.key.0)
+    }
+}
+
+impl PyStorageTaskLoad {
+    pub(crate) fn to_rust(&self) -> samod_core::io::StorageTask {
+        samod_core::io::StorageTask::Load {
+            key: self.key.0.clone(),
+        }
+    }
+}
+
+/// LoadRange task - retrieve all key-value pairs with keys starting with the prefix
+#[pyclass(name = "StorageTaskLoadRange")]
+#[derive(Clone)]
+pub struct PyStorageTaskLoadRange {
+    #[pyo3(get)]
+    pub(crate) prefix: PyStorageKey,
+}
+
+#[pymethods]
+impl PyStorageTaskLoadRange {
+    #[new]
+    fn new(prefix: PyStorageKey) -> Self {
+        PyStorageTaskLoadRange { prefix }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("StorageTaskLoadRange(prefix={})", self.prefix.0)
+    }
+}
+
+impl PyStorageTaskLoadRange {
+    pub(crate) fn to_rust(&self) -> samod_core::io::StorageTask {
+        samod_core::io::StorageTask::LoadRange {
+            prefix: self.prefix.0.clone(),
+        }
+    }
+}
+
+/// Put task - store a key-value pair
+#[pyclass(name = "StorageTaskPut")]
+#[derive(Clone)]
+pub struct PyStorageTaskPut {
+    #[pyo3(get)]
+    pub(crate) key: PyStorageKey,
+    pub(crate) value: Vec<u8>,
+}
+
+#[pymethods]
+impl PyStorageTaskPut {
+    #[new]
+    fn new(key: PyStorageKey, value: Vec<u8>) -> Self {
+        PyStorageTaskPut { key, value }
+    }
+
+    #[getter]
+    fn value<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new(py, &self.value)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("StorageTaskPut(key={}, value=<{} bytes>)", self.key.0, self.value.len())
+    }
+}
+
+impl PyStorageTaskPut {
+    pub(crate) fn to_rust(&self) -> samod_core::io::StorageTask {
+        samod_core::io::StorageTask::Put {
+            key: self.key.0.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+/// Delete task - remove a key-value pair
+#[pyclass(name = "StorageTaskDelete")]
+#[derive(Clone)]
+pub struct PyStorageTaskDelete {
+    #[pyo3(get)]
+    pub(crate) key: PyStorageKey,
+}
+
+#[pymethods]
+impl PyStorageTaskDelete {
+    #[new]
+    fn new(key: PyStorageKey) -> Self {
+        PyStorageTaskDelete { key }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("StorageTaskDelete(key={})", self.key.0)
+    }
+}
+
+impl PyStorageTaskDelete {
+    pub(crate) fn to_rust(&self) -> samod_core::io::StorageTask {
+        samod_core::io::StorageTask::Delete {
+            key: self.key.0.clone(),
+        }
+    }
+}
+
+/// Wrapper for samod_core::io::StorageResult
+///
+/// Represents the result of storage operations.
+#[pyclass(name = "StorageResult")]
+#[derive(Clone)]
+pub struct PyStorageResult(pub(crate) samod_core::io::StorageResult);
+
+#[pymethods]
+impl PyStorageResult {
+    /// Create a Load result with an optional value
+    #[staticmethod]
+    fn load(value: Option<Vec<u8>>) -> Self {
+        PyStorageResult(samod_core::io::StorageResult::Load { value })
+    }
+
+    /// Create a LoadRange result with a list of (key, value) tuples
+    #[staticmethod]
+    fn load_range(values: Vec<(PyStorageKey, Vec<u8>)>) -> Self {
+        let rust_values = values
+            .into_iter()
+            .map(|(k, v)| (k.0, v))
+            .collect::<HashMap<_, _>>();
+        PyStorageResult(samod_core::io::StorageResult::LoadRange {
+            values: rust_values,
+        })
+    }
+
+    /// Create a Put result (success)
+    #[staticmethod]
+    fn put() -> Self {
+        PyStorageResult(samod_core::io::StorageResult::Put)
+    }
+
+    /// Create a Delete result (success)
+    #[staticmethod]
+    fn delete() -> Self {
+        PyStorageResult(samod_core::io::StorageResult::Delete)
+    }
+
+    /// Check if this is a Load result
+    fn is_load(&self) -> bool {
+        matches!(self.0, samod_core::io::StorageResult::Load { .. })
+    }
+
+    /// Check if this is a LoadRange result
+    fn is_load_range(&self) -> bool {
+        matches!(self.0, samod_core::io::StorageResult::LoadRange { .. })
+    }
+
+    /// Check if this is a Put result
+    fn is_put(&self) -> bool {
+        matches!(self.0, samod_core::io::StorageResult::Put)
+    }
+
+    /// Check if this is a Delete result
+    fn is_delete(&self) -> bool {
+        matches!(self.0, samod_core::io::StorageResult::Delete)
+    }
+
+    /// Get the loaded value (only for Load results, returns None for others or if key wasn't found)
+    fn load_value<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyBytes>> {
+        match &self.0 {
+            samod_core::io::StorageResult::Load { value } => {
+                value.as_ref().map(|v| PyBytes::new(py, v))
+            }
+            _ => None,
+        }
+    }
+
+    /// Get the loaded key-value pairs (only for LoadRange results, returns None for others)
+    fn load_range_values<'py>(&self, py: Python<'py>) -> Option<Bound<'py, pyo3::types::PyDict>> {
+        match &self.0 {
+            samod_core::io::StorageResult::LoadRange { values } => {
+                let dict = pyo3::types::PyDict::new(py);
+                for (key, value) in values {
+                    let py_key = PyStorageKey(key.clone());
+                    let py_value = PyBytes::new(py, value);
+                    dict.set_item(py_key, py_value).ok()?;
+                }
+                Some(dict)
+            }
+            _ => None,
+        }
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        match &self.0 {
+            samod_core::io::StorageResult::Load { value } => {
+                if let Some(v) = value {
+                    format!("StorageResult.Load(value=<{} bytes>)", v.len())
+                } else {
+                    "StorageResult.Load(value=None)".to_string()
+                }
+            }
+            samod_core::io::StorageResult::LoadRange { values } => {
+                format!("StorageResult.LoadRange(<{} entries>)", values.len())
+            }
+            samod_core::io::StorageResult::Put => "StorageResult.Put()".to_string(),
+            samod_core::io::StorageResult::Delete => "StorageResult.Delete()".to_string(),
+        }
+    }
+}

--- a/rust/src/repo/storage.rs
+++ b/rust/src/repo/storage.rs
@@ -135,7 +135,11 @@ impl PyStorageTaskPut {
     }
 
     fn __repr__(&self) -> String {
-        format!("StorageTaskPut(key={}, value=<{} bytes>)", self.key.0, self.value.len())
+        format!(
+            "StorageTaskPut(key={}, value=<{} bytes>)",
+            self.key.0,
+            self.value.len()
+        )
     }
 }
 

--- a/rust/src/repo/types.rs
+++ b/rust/src/repo/types.rs
@@ -1,0 +1,344 @@
+//! Core identity types for the repository
+//!
+//! This module contains wrappers for fundamental identity types from samod-core,
+//! including peer IDs, storage IDs, connection IDs, document IDs, etc.
+
+use pyo3::prelude::*;
+
+/// Wrapper for samod_core::PeerId
+///
+/// Represents a unique identifier for a peer in the network. Each running instance
+/// of a repository gets a unique peer ID.
+#[pyclass(name = "PeerId")]
+#[derive(Clone)]
+pub struct PyPeerId(pub(crate) samod_core::PeerId);
+
+#[pymethods]
+impl PyPeerId {
+    /// Create a new random PeerId
+    #[staticmethod]
+    fn random() -> Self {
+        let mut rng = rand::rng();
+        PyPeerId(samod_core::PeerId::new_with_rng(&mut rng))
+    }
+
+    /// Create a PeerId from a string
+    #[staticmethod]
+    fn from_string(s: String) -> Self {
+        PyPeerId(samod_core::PeerId::from_string(s))
+    }
+
+    /// Get the string representation of this PeerId
+    fn to_string(&self) -> String {
+        self.0.as_str().to_string()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("PeerId(\"{}\")", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.0.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+// Note: FromPyObject and IntoPyObject are automatically implemented by the pyclass macro
+
+/// Wrapper for samod_core::StorageId
+///
+/// Represents a storage identifier, typically a UUID string. Each storage backend
+/// has a unique storage ID.
+#[pyclass(name = "StorageId")]
+#[derive(Clone)]
+pub struct PyStorageId(pub(crate) samod_core::StorageId);
+
+#[pymethods]
+impl PyStorageId {
+    /// Create a new random StorageId (UUID)
+    #[staticmethod]
+    fn random() -> Self {
+        let mut rng = rand::rng();
+        PyStorageId(samod_core::StorageId::new(&mut rng))
+    }
+
+    /// Create a StorageId from a string
+    #[staticmethod]
+    fn from_string(s: String) -> Self {
+        PyStorageId(samod_core::StorageId::from(s))
+    }
+
+    /// Get the string representation of this StorageId
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("StorageId(\"{}\")", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.0.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// Wrapper for samod_core::ConnectionId
+///
+/// Represents a unique identifier for a network connection. Connection IDs are
+/// automatically generated when connections are created.
+#[pyclass(name = "ConnectionId")]
+#[derive(Clone, Copy)]
+pub struct PyConnectionId(pub(crate) samod_core::ConnectionId);
+
+#[pymethods]
+impl PyConnectionId {
+    /// Create a ConnectionId from a u32
+    #[staticmethod]
+    fn from_u32(id: u32) -> Self {
+        PyConnectionId(samod_core::ConnectionId::from(id))
+    }
+
+    /// Get the u32 representation of this ConnectionId
+    fn to_u32(&self) -> u32 {
+        self.0.into()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("ConnectionId({})", u32::from(self.0))
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        format!("{}", u32::from(self.0))
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        u32::from(self.0) as u64
+    }
+}
+
+/// Wrapper for samod_core::DocumentActorId
+///
+/// Represents a unique identifier for a document actor. Each document in the repo
+/// gets its own actor with a unique ID.
+#[pyclass(name = "DocumentActorId")]
+#[derive(Clone, Copy)]
+pub struct PyDocumentActorId(pub(crate) samod_core::DocumentActorId);
+
+#[pymethods]
+impl PyDocumentActorId {
+    /// Create a new DocumentActorId
+    #[staticmethod]
+    fn new() -> Self {
+        PyDocumentActorId(samod_core::DocumentActorId::new())
+    }
+
+    /// Create a DocumentActorId from a u32
+    #[staticmethod]
+    fn from_u32(id: u32) -> Self {
+        PyDocumentActorId(samod_core::DocumentActorId::from(id))
+    }
+
+    /// Get the u32 representation of this DocumentActorId
+    fn to_u32(&self) -> u32 {
+        self.0.into()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("DocumentActorId({})", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        u32::from(self.0) as u64
+    }
+}
+
+/// Wrapper for samod_core::DocumentId
+#[pyclass(name = "DocumentId")]
+#[derive(Clone)]
+pub struct PyDocumentId(pub(crate) samod_core::DocumentId);
+
+#[pymethods]
+impl PyDocumentId {
+    /// Create a DocumentId from a string
+    #[staticmethod]
+    fn from_string(s: String) -> PyResult<Self> {
+        use std::str::FromStr;
+        samod_core::DocumentId::from_str(&s)
+            .map(PyDocumentId)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Create a DocumentId from bytes
+    #[staticmethod]
+    fn from_bytes(bytes: Vec<u8>) -> PyResult<Self> {
+        samod_core::DocumentId::try_from(bytes)
+            .map(PyDocumentId)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Get the string representation of this DocumentId
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Get the bytes representation of this DocumentId
+    fn to_bytes<'py>(&self, py: Python<'py>) -> Bound<'py, pyo3::types::PyBytes> {
+        pyo3::types::PyBytes::new(py, self.0.as_bytes())
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("DocumentId(\"{}\")", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.0.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// Wrapper for samod_core::AutomergeUrl
+///
+/// Represents a URL to an Automerge document or a path within a document.
+/// Format: "automerge:{document_id}[/path/to/property]"
+#[pyclass(name = "AutomergeUrl")]
+#[derive(Clone)]
+pub struct PyAutomergeUrl(pub(crate) samod_core::AutomergeUrl);
+
+#[pymethods]
+impl PyAutomergeUrl {
+    /// Create an AutomergeUrl from a string
+    #[staticmethod]
+    fn from_str(s: String) -> PyResult<Self> {
+        use std::str::FromStr;
+        samod_core::AutomergeUrl::from_str(&s)
+            .map(PyAutomergeUrl)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Create an AutomergeUrl from a DocumentId
+    #[staticmethod]
+    fn from_document_id(document_id: &PyDocumentId) -> PyResult<Self> {
+        use std::str::FromStr;
+        let url_str = format!("automerge:{}", document_id.0);
+        samod_core::AutomergeUrl::from_str(&url_str)
+            .map(PyAutomergeUrl)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Get the document ID from this AutomergeUrl
+    fn document_id(&self) -> PyResult<PyDocumentId> {
+        use std::str::FromStr;
+        // Extract the document ID by parsing the URL string
+        // Format: "automerge:<document_id>[/path...]"
+        let url_str = self.0.to_string();
+        let doc_id_str = url_str
+            .strip_prefix("automerge:")
+            .ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid automerge URL")
+            })?
+            .split('/')
+            .next()
+            .ok_or_else(|| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>("No document ID in URL")
+            })?;
+
+        samod_core::DocumentId::from_str(doc_id_str)
+            .map(PyDocumentId)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))
+    }
+
+    /// Get the string representation of this AutomergeUrl
+    fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// String representation for debugging
+    fn __repr__(&self) -> String {
+        format!("AutomergeUrl(\"{}\")", self.0)
+    }
+
+    /// String representation
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Equality comparison
+    fn __eq__(&self, other: &Self) -> bool {
+        self.0.to_string() == other.0.to_string()
+    }
+
+    /// Hash support
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.0.to_string().hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/src/automerge/__init__.py
+++ b/src/automerge/__init__.py
@@ -1,4 +1,4 @@
-from ._automerge import ROOT, ObjType, ScalarType
+from ._automerge import ROOT, ObjType, ScalarType, enable_tracing
 from .document import Document, ImmutableString, MutableText, Text
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     "ScalarType",
     "Text",
     "MutableText",
+    "enable_tracing",
 ]

--- a/src/automerge/core/__init__.py
+++ b/src/automerge/core/__init__.py
@@ -54,5 +54,3 @@ def extract(doc: Document, obj_id: bytes = ROOT) -> Thing:
 
 
 __doc__ = _automerge.__doc__
-# if hasattr(_automerge, "__all__"):
-#     __all__ = _automerge.__all__

--- a/src/automerge/repo.py
+++ b/src/automerge/repo.py
@@ -1,0 +1,1488 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Union,
+)
+
+from automerge._automerge import (
+    AutomergeUrl,
+    CheckAnnouncePolicyAction,
+    CommandId,
+    CommandResultCreateConnection,
+    CommandResultCreateDocument,
+    CommandResultFindDocument,
+    ConnDirection,
+    ConnectionId,
+    DisconnectAction,
+    DispatchedCommand,
+    DocumentActor,
+    DocumentActorId,
+    DocumentId,
+    Hub,
+    HubEvent,
+    IoResult,
+    IoTask,
+    LoaderStateLoaded,
+    LoaderStateNeedIo,
+    PeerId,
+    SamodLoader,
+    SendAction,
+    SpawnArgs,
+    StorageKey,
+    StorageResult,
+    StorageTaskAction,
+    StorageTaskDelete,
+    StorageTaskLoad,
+    StorageTaskLoadRange,
+    StorageTaskPut,
+)
+
+
+class Storage(Protocol):
+    """Protocol for storage adapters.
+
+    Storage adapters are responsible for persisting repository data. They must
+    implement the load, load_range, put, and delete methods to handle storage
+    operations requested by the repository.
+    """
+
+    async def load(self, key: StorageKey) -> Optional[bytes]:
+        """Load a value from storage.
+
+        Args:
+            key: The storage key to load
+
+        Returns:
+            The stored bytes if the key exists, None otherwise
+        """
+        ...
+
+    async def load_range(self, prefix: StorageKey) -> List[Tuple[StorageKey, bytes]]:
+        """Load all keys with the given prefix.
+
+        Args:
+            prefix: The key prefix to match
+
+        Returns:
+            List of (key, value) tuples for all matching keys
+        """
+        ...
+
+    async def put(self, key: StorageKey, value: bytes) -> None:
+        """Store a value in storage.
+
+        Args:
+            key: The storage key
+            value: The bytes to store
+        """
+        ...
+
+    async def delete(self, key: StorageKey) -> None:
+        """Delete a value from storage.
+
+        Args:
+            key: The storage key to delete
+        """
+        ...
+
+
+# Announce Policy Types
+
+
+class AnnouncePolicy(Protocol):
+    """Protocol for class-based announce policies.
+
+    Announce policies control which documents are announced to which peers during
+    synchronization. This allows for privacy, security, and performance optimization
+    by selectively sharing documents based on custom logic.
+
+    Implement this protocol by providing an async `should_announce` method that
+    returns True if a document should be announced to a peer, False otherwise.
+
+    Example:
+        class TrustedPeerPolicy:
+            def __init__(self, trusted_peers: set[str]):
+                self.trusted_peers = trusted_peers
+
+            async def should_announce(self, document_id: str, peer_id: str) -> bool:
+                return peer_id in self.trusted_peers
+    """
+
+    async def should_announce(self, document_id: str, peer_id: str) -> bool:
+        """Check if a document should be announced to a peer.
+
+        Args:
+            document_id: The document ID to potentially announce
+            peer_id: The peer ID requesting the document
+
+        Returns:
+            True if the document should be announced, False otherwise
+        """
+        ...
+
+
+# Function-based announce policy type
+AnnouncePolicyFunc = Callable[[str, str], Awaitable[bool]]
+
+# Combined type for Repo parameter
+AnnouncePolicyType = Union[AnnouncePolicyFunc, AnnouncePolicy, None]
+
+
+class InMemoryStorage:
+    """Simple in-memory storage implementation.
+
+    This storage adapter keeps all data in memory using a dictionary. It's
+    useful for testing and development, but data is not persisted across
+    process restarts.
+    """
+
+    def __init__(self):
+        self._storage: Dict[str, bytes] = {}
+
+    async def load(self, key: StorageKey) -> Optional[bytes]:
+        """Load a value from memory."""
+        key_str = self._key_to_str(key)
+        return self._storage.get(key_str)
+
+    async def load_range(self, prefix: StorageKey) -> List[Tuple[StorageKey, bytes]]:
+        """Load all keys with the given prefix from memory."""
+        prefix_str = self._key_to_str(prefix) + "/"
+        results = []
+        for key_str, value in self._storage.items():
+            if key_str.startswith(prefix_str):
+                # Convert back to StorageKey
+                parts = key_str.split("/")
+                key = StorageKey.from_parts(parts)
+                results.append((key, value))
+        return results
+
+    async def put(self, key: StorageKey, value: bytes) -> None:
+        """Store a value in memory."""
+        key_str = self._key_to_str(key)
+        self._storage[key_str] = value
+
+    async def delete(self, key: StorageKey) -> None:
+        """Delete a value from memory."""
+        key_str = self._key_to_str(key)
+        self._storage.pop(key_str, None)
+
+    def _key_to_str(self, key: StorageKey) -> str:
+        """Convert a StorageKey to a string for use as dict key."""
+        return "/".join(key.to_parts())
+
+
+class FileSystemStorage:
+    """File system storage implementation.
+
+    This storage adapter persists data to files on disk. Each storage key
+    maps to a file path where all components except the last become directories
+    and the last component becomes the filename.
+
+    The top-level directory is splayed over two levels using the first two
+    characters of the first key component (similar to git's object storage).
+    For example, a key ["abc123", "data"] becomes "ab/c123/data".
+
+    This design improves performance by avoiding directories with too many
+    entries, which can slow down file system operations.
+    """
+
+    def __init__(self, base_path: Union[str, Path]):
+        """Initialize the file system storage.
+
+        Args:
+            base_path: The base directory for storing files. Will be created
+                if it doesn't exist.
+        """
+        self._base_path = Path(base_path)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+    def _key_to_path(self, key: StorageKey) -> Path:
+        """Convert a StorageKey to a file system path.
+
+        The first component is splayed: "abc123" becomes "ab/c123".
+        Remaining components become nested directories, with the last
+        component being the filename.
+
+        Args:
+            key: The storage key to convert
+
+        Returns:
+            The file system path for this key
+
+        Raises:
+            ValueError: If the first key component has fewer than 3 characters
+        """
+        parts = key.to_parts()
+        if not parts:
+            raise ValueError("Storage key must have at least one part")
+
+        # Splay the first component: use first 2 chars as a directory
+        first = parts[0]
+        if len(first) < 3:
+            raise ValueError(
+                f"First key component must have at least 3 characters, got {len(first)!r}"
+            )
+
+        splayed = [first[:2], first[2:]]
+
+        # Build the full path: base / splay_dir / splay_rest / remaining_parts
+        path_parts = splayed + list(parts[1:])
+        return self._base_path.joinpath(*path_parts)
+
+    def _path_to_key(self, path: Path) -> StorageKey:
+        """Convert a file system path back to a StorageKey.
+
+        Reverses the splaying operation to reconstruct the original key.
+
+        Args:
+            path: The file system path (relative to base_path)
+
+        Returns:
+            The reconstructed StorageKey
+        """
+        # Get path parts relative to base
+        rel_path = path.relative_to(self._base_path)
+        parts = list(rel_path.parts)
+
+        if len(parts) < 2:
+            raise ValueError(f"Invalid storage path: {path}")
+
+        # Unsplay the first two components back into one
+        splay_dir = parts[0]
+        splay_rest = parts[1]
+
+        # Reconstruct original first component
+        first = splay_dir + splay_rest
+
+        # Rebuild the key parts
+        key_parts = [first] + parts[2:]
+        return StorageKey.from_parts(key_parts)
+
+    async def load(self, key: StorageKey) -> Optional[bytes]:
+        """Load a value from the file system.
+
+        Args:
+            key: The storage key to load
+
+        Returns:
+            The stored bytes if the file exists, None otherwise
+        """
+        path = self._key_to_path(key)
+        if not path.exists():
+            return None
+
+        # Use asyncio to avoid blocking
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, path.read_bytes)
+
+    async def load_range(self, prefix: StorageKey) -> List[Tuple[StorageKey, bytes]]:
+        """Load all keys with the given prefix from the file system.
+
+        Uses directory listing to find all files under the prefix path.
+
+        Args:
+            prefix: The key prefix to match
+
+        Returns:
+            List of (key, value) tuples for all matching keys
+        """
+        prefix_path = self._key_to_path(prefix)
+
+        # If prefix path doesn't exist, return empty list
+        if not prefix_path.exists():
+            return []
+
+        results = []
+        loop = asyncio.get_event_loop()
+
+        # Walk the directory tree
+        def collect_files():
+            files = []
+            if prefix_path.is_dir():
+                for root, _, filenames in os.walk(prefix_path):
+                    for filename in filenames:
+                        file_path = Path(root) / filename
+                        files.append(file_path)
+            return files
+
+        files = await loop.run_in_executor(None, collect_files)
+
+        # Read all files and convert paths back to keys
+        for file_path in files:
+            key = self._path_to_key(file_path)
+            value = await loop.run_in_executor(None, file_path.read_bytes)
+            results.append((key, value))
+
+        return results
+
+    async def put(self, key: StorageKey, value: bytes) -> None:
+        """Store a value to the file system.
+
+        Creates parent directories as needed.
+
+        Args:
+            key: The storage key
+            value: The bytes to store
+        """
+        path = self._key_to_path(key)
+
+        # Create parent directories
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None, lambda: path.parent.mkdir(parents=True, exist_ok=True)
+        )
+
+        # Write the file
+        await loop.run_in_executor(None, lambda: path.write_bytes(value))
+
+    async def delete(self, key: StorageKey) -> None:
+        """Delete a value from the file system.
+
+        Args:
+            key: The storage key to delete
+        """
+        path = self._key_to_path(key)
+
+        if not path.exists():
+            return
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, path.unlink)
+
+
+class Transport(Protocol):
+    """Protocol for network transports.
+
+    Transports handle sending and receiving messages between peers.
+    """
+
+    async def send(self, msg: bytes):
+        """Send a message to the peer.
+
+        Args:
+            msg: The message bytes to send
+        """
+        ...
+
+    async def recv(self) -> bytes:
+        """Receive a message from the peer.
+
+        Returns:
+            The received message bytes
+        """
+        ...
+
+    async def close(self):
+        """Close the transport connection.
+
+        This should clean up any resources and stop any background tasks
+        associated with the transport.
+        """
+        ...
+
+
+class ConnFinishedReason(Enum):
+    Shutdown = 0
+    TheyDisconnected = 1
+    WeDisconnected = 2
+    ErrorSending = 3
+    ErrorReceiving = 4
+
+
+class Repo:
+    """Automerge repository for managing documents with synchronization.
+
+    The Repo manages multiple Automerge documents, handles synchronization
+    with other peers, and persists data through a storage adapter.
+
+    Lifecycle:
+        1. Load the repository from storage (creates Hub)
+        2. Start the Hub event loop
+        3. Use the repository
+        4. Stop the Hub event loop
+
+    Examples:
+        ```python
+        # Using context manager (recommended)
+        repo = await Repo.load(InMemoryStorage())
+        async with repo:
+            handle = await repo.create()
+            # Use the repo...
+
+        # Manual lifecycle control (advanced)
+        repo = await Repo.load(storage)
+        await repo.start()
+        try:
+            # Use the repo...
+        finally:
+            await repo.stop()
+        ```
+    """
+
+    def __init__(
+        self,
+        storage: Storage,
+        peer_id: PeerId,
+        hub: Hub,
+        announce_policy: AnnouncePolicyType = None,
+    ):
+        """Initialize a repository (internal - use Repo.load() instead).
+
+        Args:
+            storage: Storage adapter for persisting repository data
+            peer_id: The peer ID for this repository
+            hub: The loaded Hub instance
+            announce_policy: Optional policy to control document announcement to peers.
+                If None, all documents are announced to all peers (default).
+        """
+        self._storage = storage
+        self._peer_id = peer_id
+        self._hub = hub
+        self._announce_policy = announce_policy
+        self._hub_task: Optional[asyncio.Task] = None
+        self._hub_event_queue: asyncio.Queue[HubEvent] = asyncio.Queue()
+        self._pending_commands: Dict[CommandId, asyncio.Future] = {}
+        self._shutdown_event = asyncio.Event()
+        self._started = False
+
+        # Document actor management
+        self._doc_actors: Dict[DocumentActorId, DocumentActor] = {}
+        self._doc_actor_tasks: Dict[DocumentActorId, asyncio.Task] = {}
+        self._doc_actor_queues: Dict[DocumentActorId, asyncio.Queue] = {}
+        self._actor_to_doc: Dict[
+            DocumentActorId, DocumentId
+        ] = {}  # Maps actor_id to document_id
+
+        # Connection management
+        self._transports: Dict[ConnectionId, Transport] = {}
+        self._recv_tasks: Dict[ConnectionId, asyncio.Task] = {}
+        self._send_tasks: Dict[ConnectionId, asyncio.Task] = {}
+        self._send_queues: Dict[ConnectionId, asyncio.Queue] = {}
+        self._conn_finished_futures: Dict[ConnectionId, asyncio.Future] = {}
+
+    @classmethod
+    async def load(
+        cls,
+        storage: Optional[Storage] = None,
+        peer_id: Optional[bytes] = None,
+        announce_policy: AnnouncePolicyType = None,
+    ) -> "Repo":
+        """Load a repository from storage.
+
+        This runs the loader loop to initialize the Hub but does not start
+        the Hub event loop. Call start() or use as a context manager to begin
+        processing events.
+
+        Args:
+            storage: Storage adapter for persisting repository data
+            peer_id: Optional peer ID bytes. If None, a random ID is generated.
+            announce_policy: Optional policy to control which documents are announced
+                to which peers during synchronization. Can be:
+                - An async function: `async def policy(document_id: str, peer_id: str) -> bool`
+                - An object implementing the AnnouncePolicy protocol with an async
+                  `should_announce(document_id, peer_id)` method
+                - None (default): all documents are announced to all peers
+
+                Example function-based policy:
+                    ```python
+                    async def allow_public_docs(document_id: str, peer_id: str) -> bool:
+                        # Only announce documents starting with "public-"
+                        return document_id.startswith("public-")
+
+                    repo = await Repo.load(storage, announce_policy=allow_public_docs)
+                    ```
+
+                Example class-based policy with state:
+                    ```python
+                    class TrustedPeerPolicy:
+                        def __init__(self, trusted_peers: set[str]):
+                            self.trusted_peers = trusted_peers
+
+                        async def should_announce(self, document_id: str, peer_id: str) -> bool:
+                            return peer_id in self.trusted_peers
+
+                    policy = TrustedPeerPolicy({"peer-alice", "peer-bob"})
+                    repo = await Repo.load(storage, announce_policy=policy)
+                    ```
+
+                Error Handling: If the policy raises an exception during evaluation,
+                the error is logged and the document is NOT announced (fail-closed for
+                security). This ensures that policy errors don't accidentally leak
+                sensitive documents.
+
+        Returns:
+            A loaded Repo instance (not yet started)
+        """
+        # Create peer ID
+        py_peer_id = PeerId.from_string(peer_id.hex()) if peer_id else PeerId.random()
+
+        # Create loader
+        loader = SamodLoader(py_peer_id)
+
+        if storage is None:
+            storage = InMemoryStorage()
+
+        # Helper to execute IO task (need access to storage)
+        async def execute_io_task(io_task: IoTask) -> IoResult:
+            action = io_task.action
+
+            if isinstance(action, StorageTaskAction):
+                task = action.task
+
+                if isinstance(task, StorageTaskLoad):
+                    value = await storage.load(task.key)
+                    storage_result = StorageResult.load(value)
+                    return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+                elif isinstance(task, StorageTaskLoadRange):
+                    values = await storage.load_range(task.prefix)
+                    storage_result = StorageResult.load_range(values)
+                    return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+                elif isinstance(task, StorageTaskPut):
+                    await storage.put(task.key, bytes(task.value))
+                    storage_result = StorageResult.put()
+                    return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+                elif isinstance(task, StorageTaskDelete):
+                    await storage.delete(task.key)
+                    storage_result = StorageResult.delete()
+                    return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+            raise ValueError(f"Unknown IO task action type during load: {type(action)}")
+
+        # Loading loop - execute IO tasks until Hub is loaded
+        while True:
+            state = loader.step(time.time())
+
+            if isinstance(state, LoaderStateNeedIo):
+                # Execute all IO tasks
+                tasks = state.tasks
+                for io_task in tasks:
+                    result = await execute_io_task(io_task)
+                    loader.provide_io_result(result)
+            elif isinstance(state, LoaderStateLoaded):
+                # Loading complete - get the Hub
+                hub = state.hub
+                break
+
+        # Create and return the Repo instance
+        return cls(storage, py_peer_id, hub, announce_policy)
+
+    async def start(self):
+        """Start the Hub event loop.
+
+        This begins processing events in the background. Can only be called once.
+
+        Raises:
+            RuntimeError: If the Hub loop is already started
+        """
+        if self._started:
+            raise RuntimeError("Repo already started")
+
+        self._started = True
+        self._hub_task = asyncio.create_task(self._hub_loop())
+
+    async def stop(self):
+        """Stop the Hub event loop.
+
+        This signals shutdown and waits for the Hub loop to finish.
+        Safe to call multiple times.
+        """
+        if not self._started:
+            return
+
+        # Signal shutdown
+        self._shutdown_event.set()
+        await self._hub_event_queue.put(HubEvent.stop())
+
+        # Wait for Hub loop to finish processing the stop event
+        # This allows the hub to emit any DisconnectActions and clean up gracefully
+        if self._hub_task:
+            await self._hub_task
+            self._hub_task = None
+
+        # After hub has stopped, cancel any remaining connection finished futures
+        # This will unblock any tasks still waiting on repo.connect()/repo.accept()
+        for future in list(self._conn_finished_futures.values()):
+            if not future.done():
+                future.cancel()
+
+        # Cancel all remaining tasks
+        for task in list(self._recv_tasks.values()):
+            task.cancel()
+        for task in list(self._send_tasks.values()):
+            task.cancel()
+        for task in list(self._doc_actor_tasks.values()):
+            task.cancel()
+
+        # Close any remaining transports
+        # (The hub should have closed most of them via DisconnectActions)
+        for conn_id, transport in list(self._transports.items()):
+            try:
+                await transport.close()
+            except Exception as e:
+                print(f"Error closing transport during shutdown: {e}")
+
+        # Wait for all tasks to complete
+        all_tasks = (
+            list(self._recv_tasks.values())
+            + list(self._send_tasks.values())
+            + list(self._doc_actor_tasks.values())
+        )
+        if all_tasks:
+            await asyncio.gather(*all_tasks, return_exceptions=True)
+
+        # Cancel any pending commands
+        for future in self._pending_commands.values():
+            if not future.done():
+                future.cancel()
+
+        self._started = False
+
+    async def __aenter__(self):
+        """Enter the async context manager - start the Hub loop if not started."""
+        if not self._started:
+            await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit the async context manager - stop the Hub loop."""
+        await self.stop()
+        return False
+
+    async def _hub_loop(self):
+        """Main Hub event processing loop.
+
+        This loop:
+        1. Waits for events from the event queue
+        2. Processes events through the Hub
+        3. Executes resulting IO tasks
+        4. Completes pending commands
+        5. Handles connection events
+        """
+        while not self._shutdown_event.is_set():
+            try:
+                # Wait for an event with timeout to check shutdown
+                try:
+                    event = await asyncio.wait_for(
+                        self._hub_event_queue.get(), timeout=0.1
+                    )
+                except asyncio.TimeoutError:
+                    # Send periodic tick event
+                    event = HubEvent.tick()
+
+                # Process event through Hub
+                # print(f"[DEBUG HUB] Processing event: {type(event).__name__}")
+                results = self._hub.handle_event(time.time(), event)
+
+                # Execute new IO tasks
+                for io_task in results.new_tasks:
+                    # Execute task and feed result back to Hub
+                    asyncio.create_task(self._handle_io_task(io_task))
+
+                # Complete pending commands
+                for cmd_id, cmd_result in results.completed_commands.items():
+                    # If this is a create_connection command, set up send queue immediately
+                    if isinstance(cmd_result, CommandResultCreateConnection):
+                        conn_id = cmd_result.connection_id
+                        if conn_id not in self._send_queues:
+                            self._send_queues[conn_id] = asyncio.Queue()
+
+                    if cmd_id in self._pending_commands:
+                        future = self._pending_commands.pop(cmd_id)
+                        if not future.done():
+                            future.set_result(cmd_result)
+
+                # Handle connection events
+                for conn_event in results.connection_events:
+                    # Connection events are informational - no action needed for now
+                    pass
+
+                # Handle document actor spawning
+                for spawn_args in results.spawn_actors:
+                    asyncio.create_task(self._spawn_document_actor(spawn_args))
+
+                # Handle messages to document actors
+                for actor_id, msg in results.actor_messages:
+                    if actor_id in self._doc_actor_queues:
+                        await self._doc_actor_queues[actor_id].put(msg)
+                    else:
+                        print(f"Warning: Message for unknown actor {actor_id}")
+
+                # Check if Hub stopped
+                if results.stopped:
+                    break
+
+            except Exception as e:
+                # Log error but keep loop running
+                print(f"Error in Hub loop: {e}")
+                import traceback
+
+                traceback.print_exc()
+
+    async def _check_announce_policy(self, document_id: str, peer_id: str) -> bool:
+        """Check announce policy for a document and peer.
+
+        Args:
+            document_id: The document ID to check
+            peer_id: The peer ID to check against
+
+        Returns:
+            True if the document should be announced, False otherwise
+        """
+        if self._announce_policy is None:
+            # Default: announce everything (backwards compatible)
+            return True
+
+        try:
+            if callable(self._announce_policy):
+                # Async function
+                return await self._announce_policy(document_id, peer_id)
+            else:
+                # Class-based policy
+                return await self._announce_policy.should_announce(document_id, peer_id)
+        except Exception as e:
+            # Fail closed: deny on error for security
+            print(
+                f"Error in announce policy check for document {document_id}, peer {peer_id}: {e}"
+            )
+            import traceback
+
+            traceback.print_exc()
+            return False
+
+    async def _execute_io_task(
+        self, io_task: IoTask, actor_id: Optional[DocumentActorId] = None
+    ) -> IoResult:
+        """Execute a single IO task and return the result.
+
+        Args:
+            io_task: The IO task to execute
+            actor_id: Optional document actor ID for document-specific tasks
+
+        Returns:
+            The result of executing the task
+        """
+        action = io_task.action
+
+        if isinstance(action, StorageTaskAction):
+            # Execute storage operation - use isinstance to determine task type
+            task = action.task
+
+            if isinstance(task, StorageTaskLoad):
+                value = await self._storage.load(task.key)
+                storage_result = StorageResult.load(value)
+                return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+            elif isinstance(task, StorageTaskLoadRange):
+                values = await self._storage.load_range(task.prefix)
+                storage_result = StorageResult.load_range(values)
+                return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+            elif isinstance(task, StorageTaskPut):
+                await self._storage.put(task.key, bytes(task.value))
+                storage_result = StorageResult.put()
+                return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+            elif isinstance(task, StorageTaskDelete):
+                await self._storage.delete(task.key)
+                storage_result = StorageResult.delete()
+                return IoResult.from_storage_result(io_task.task_id, storage_result)
+
+        elif isinstance(action, SendAction):
+            # Enqueue message for sending - the send loop will handle it in order
+            conn_id = action.connection_id
+
+            if conn_id in self._send_queues:
+                # Queue the IO task - the send loop will process it
+                await self._send_queues[conn_id].put(io_task)
+            else:
+                # Connection doesn't exist or was already closed
+                raise ValueError(f"Connection {conn_id} not found")
+
+            # Return None - we'll send io_complete from the send loop
+            return None
+
+        elif isinstance(action, DisconnectAction):
+            # Disconnect from peer
+            conn_id = action.connection_id
+
+            if conn_id in self._conn_finished_futures:
+                future = self._conn_finished_futures.pop(conn_id)
+                if not future.done():
+                    future.set_result(ConnFinishedReason.WeDisconnected)
+
+            # Close the transport
+            if conn_id in self._transports:
+                transport = self._transports[conn_id]
+                try:
+                    await transport.close()
+                except Exception as e:
+                    print(f"Error closing transport for connection {conn_id}: {e}")
+                del self._transports[conn_id]
+
+            # Cancel and clean up tasks
+            if conn_id in self._recv_tasks:
+                self._recv_tasks[conn_id].cancel()
+                del self._recv_tasks[conn_id]
+            if conn_id in self._send_tasks:
+                self._send_tasks[conn_id].cancel()
+                del self._send_tasks[conn_id]
+            if conn_id in self._send_queues:
+                del self._send_queues[conn_id]
+
+            # Return success result
+            return IoResult.from_disconnect_result(io_task.task_id)
+
+        elif isinstance(action, CheckAnnouncePolicyAction):
+            # Check announce policy
+            if actor_id is None:
+                raise ValueError("actor_id required for CheckAnnouncePolicyAction")
+
+            # Look up document_id from actor_id
+            document_id = self._actor_to_doc.get(actor_id)
+            if document_id is None:
+                # Actor not found - deny by default
+                print(
+                    f"Warning: actor_id {actor_id} not found in _actor_to_doc mapping"
+                )
+                should_announce = False
+            else:
+                # Get peer_id from action and check policy
+                peer_id = str(action.peer_id)
+                document_id_str = str(document_id)
+                should_announce = await self._check_announce_policy(
+                    document_id_str, peer_id
+                )
+
+            return IoResult.from_check_announce_policy_result(
+                io_task.task_id, should_announce=should_announce
+            )
+
+        raise ValueError(f"Unknown IO task action type: {type(action)}")
+
+    async def _handle_io_task(self, io_task: IoTask):
+        """Execute an IO task and feed the result back to the Hub.
+
+        Args:
+            io_task: The IO task to execute
+        """
+        try:
+            result = await self._execute_io_task(io_task)
+            # Send io_complete event to Hub for network operations
+            # Storage operations complete synchronously within handle_event
+            if result is not None:
+                await self._hub_event_queue.put(HubEvent.io_complete(result))
+        except Exception as e:
+            print(f"Error executing IO task: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    async def _dispatch_command(self, command: DispatchedCommand) -> Any:
+        """Dispatch a command to the Hub and wait for completion.
+
+        Args:
+            command: The command to dispatch
+
+        Returns:
+            The command result
+        """
+        # Create future for this command
+        future = asyncio.Future()
+        self._pending_commands[command.command_id] = future
+
+        # Send event to Hub
+        await self._hub_event_queue.put(command.event)
+
+        # Wait for completion
+        return await future
+
+    async def _spawn_document_actor(self, spawn_args: SpawnArgs):
+        """Spawn a new document actor.
+
+        Args:
+            spawn_args: Arguments for spawning the actor
+        """
+        actor_id = spawn_args.actor_id
+        document_id = spawn_args.document_id
+
+        # Create the document actor - returns (actor, initial_result)
+        actor, initial_result = DocumentActor.new(time.time(), spawn_args)
+
+        # Store the actor and document mapping
+        self._doc_actors[actor_id] = actor
+        self._actor_to_doc[actor_id] = document_id
+
+        # Create message queue for this actor
+        queue = asyncio.Queue()
+        self._doc_actor_queues[actor_id] = queue
+
+        # Handle initial IO tasks from spawn
+        for io_task in initial_result.io_tasks:
+            asyncio.create_task(self._handle_doc_actor_io(actor_id, io_task))
+
+        # Handle initial outgoing messages
+        for msg in initial_result.outgoing_messages:
+            # Send message back to Hub event queue
+            await self._hub_event_queue.put(HubEvent.actor_message(actor_id, msg))
+
+        # Start the actor's control loop
+        task = asyncio.create_task(self._document_actor_loop(actor_id))
+        self._doc_actor_tasks[actor_id] = task
+
+    async def _document_actor_loop(self, actor_id: DocumentActorId):
+        """Main loop for a document actor.
+
+        Args:
+            actor_id: The document actor ID
+        """
+        queue = self._doc_actor_queues[actor_id]
+        actor = self._doc_actors[actor_id]
+
+        try:
+            while not self._shutdown_event.is_set():
+                try:
+                    # Wait for message with timeout to check shutdown
+                    msg = await asyncio.wait_for(queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+
+                # Process message through document actor
+                result = actor.handle_message(time.time(), msg)
+
+                # Execute IO tasks
+                for io_task in result.io_tasks:
+                    asyncio.create_task(self._handle_doc_actor_io(actor_id, io_task))
+
+                # Send outgoing messages to Hub
+                for outgoing_msg in result.outgoing_messages:
+                    await self._hub_event_queue.put(
+                        HubEvent.actor_message(actor_id, outgoing_msg)
+                    )
+
+                # Check if actor stopped
+                if result.stopped:
+                    break
+
+        except Exception as e:
+            print(f"Error in document actor loop for {actor_id}: {e}")
+            import traceback
+
+            traceback.print_exc()
+        finally:
+            # Clean up
+            if actor_id in self._doc_actors:
+                del self._doc_actors[actor_id]
+            if actor_id in self._doc_actor_queues:
+                del self._doc_actor_queues[actor_id]
+            if actor_id in self._doc_actor_tasks:
+                del self._doc_actor_tasks[actor_id]
+            if actor_id in self._actor_to_doc:
+                del self._actor_to_doc[actor_id]
+
+    async def _handle_doc_actor_io(self, actor_id: DocumentActorId, io_task: IoTask):
+        """Execute an IO task for a document actor.
+
+        Args:
+            actor_id: The document actor ID
+            io_task: The IO task to execute
+        """
+        try:
+            # Execute the IO task (pass actor_id for document-specific tasks)
+            result = await self._execute_io_task(io_task, actor_id)
+
+            # Get the actor and feed the result back
+            if actor_id in self._doc_actors:
+                actor = self._doc_actors[actor_id]
+                doc_result = actor.handle_io_complete(time.time(), result)
+
+                # Execute any new IO tasks that resulted
+                for new_io_task in doc_result.io_tasks:
+                    asyncio.create_task(
+                        self._handle_doc_actor_io(actor_id, new_io_task)
+                    )
+
+                # Handle outgoing messages
+                for outgoing_msg in doc_result.outgoing_messages:
+                    await self._hub_event_queue.put(
+                        HubEvent.actor_message(actor_id, outgoing_msg)
+                    )
+
+        except Exception as e:
+            print(f"Error handling IO task for document actor {actor_id}: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    async def _send_loop(self, conn_id: ConnectionId, transport: Transport):
+        """Send loop for a connection.
+
+        Continuously processes send tasks from the queue and sends messages
+        in FIFO order to maintain message ordering required by samod-core.
+
+        Args:
+            conn_id: The connection ID
+            transport: The transport to send on
+        """
+        try:
+            queue = self._send_queues[conn_id]
+            while not self._shutdown_event.is_set():
+                try:
+                    # Wait for a send task with timeout to check shutdown
+                    io_task = await asyncio.wait_for(queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+
+                # Extract the message from the SendAction
+                action = io_task.action
+                if not isinstance(action, SendAction):
+                    print(f"Warning: Non-SendAction in send queue: {type(action)}")
+                    continue
+
+                message = action.message
+
+                try:
+                    # Send the message
+                    await transport.send(bytes(message))
+
+                    # Send io_complete event to Hub
+                    result = IoResult.from_send_result(io_task.task_id)
+                    await self._hub_event_queue.put(HubEvent.io_complete(result))
+
+                except asyncio.CancelledError:
+                    # Connection was disconnected from our side
+                    # Notify Hub about the disconnection
+                    await self._hub_event_queue.put(HubEvent.connection_lost(conn_id))
+                    break
+                except Exception as e:
+                    # Error sending - connection failed
+                    print(f"Error sending on connection {conn_id}: {e}")
+                    if conn_id in self._conn_finished_futures:
+                        future = self._conn_finished_futures.pop(conn_id)
+                        if not future.done():
+                            future.set_result(ConnFinishedReason.ErrorSending)
+                    # Notify Hub about connection lost
+                    await self._hub_event_queue.put(HubEvent.connection_lost(conn_id))
+                    break
+
+        finally:
+            # Clean up
+            if conn_id in self._send_queues:
+                del self._send_queues[conn_id]
+            if conn_id in self._send_tasks:
+                del self._send_tasks[conn_id]
+
+    async def _recv_loop(self, conn_id: ConnectionId, transport: Transport):
+        """Receive loop for a connection.
+
+        Continuously receives messages from the transport and dispatches them
+        to the Hub until the connection is closed or an error occurs.
+
+        Args:
+            conn_id: The connection ID
+            transport: The transport to receive from
+        """
+        try:
+            while not self._shutdown_event.is_set():
+                try:
+                    # Receive message from transport
+                    msg = await transport.recv()
+
+                    # Put receive event in queue (don't wait for completion to avoid blocking recv loop)
+                    receive_cmd = HubEvent.receive(conn_id, msg)
+                    await self._hub_event_queue.put(receive_cmd.event)
+
+                except asyncio.CancelledError:
+                    # Connection was disconnected from our side
+                    # Notify Hub about the disconnection
+                    await self._hub_event_queue.put(HubEvent.connection_lost(conn_id))
+                    break
+                except Exception as e:
+                    # Error receiving - connection failed
+                    print(f"Error receiving on connection {conn_id}: {e}")
+                    if conn_id in self._conn_finished_futures:
+                        future = self._conn_finished_futures.pop(conn_id)
+                        if not future.done():
+                            future.set_result(ConnFinishedReason.ErrorReceiving)
+                    # Notify Hub about connection lost
+                    await self._hub_event_queue.put(HubEvent.connection_lost(conn_id))
+                    break
+
+        finally:
+            # Clean up
+            if conn_id in self._transports:
+                del self._transports[conn_id]
+            if conn_id in self._recv_tasks:
+                del self._recv_tasks[conn_id]
+            # Cancel send loop if it's still running
+            if conn_id in self._send_tasks:
+                self._send_tasks[conn_id].cancel()
+            if conn_id in self._send_queues:
+                del self._send_queues[conn_id]
+
+    async def _establish_connection(
+        self, transport: Transport, direction: ConnDirection
+    ) -> ConnFinishedReason:
+        """Internal helper to establish a connection with the given direction.
+
+        Args:
+            transport: The transport to use for communication
+            direction: The connection direction (Outgoing or Incoming)
+
+        Returns:
+            The reason the connection finished
+        """
+        # Create connection command with the specified direction
+        command = HubEvent.create_connection(direction)
+
+        result = await self._dispatch_command(command)
+
+        # Result should be CommandResultCreateConnection
+        if not isinstance(result, CommandResultCreateConnection):
+            raise RuntimeError(f"Unexpected result type: {type(result)}")
+
+        conn_id = result.connection_id
+
+        # Store transport
+        self._transports[conn_id] = transport
+
+        # Send queue was already created in _hub_loop when the command completed
+        # Start the send loop to process messages from the queue
+        send_task = asyncio.create_task(self._send_loop(conn_id, transport))
+        self._send_tasks[conn_id] = send_task
+
+        # Create future for connection finished reason
+        future = asyncio.Future()
+        self._conn_finished_futures[conn_id] = future
+
+        # Start receive loop
+        recv_task = asyncio.create_task(self._recv_loop(conn_id, transport))
+        self._recv_tasks[conn_id] = recv_task
+
+        # Wait for connection to finish
+        try:
+            reason = await future
+            return reason
+        except asyncio.CancelledError:
+            # Shutdown - cancel receive task
+            recv_task.cancel()
+            try:
+                await recv_task
+            except asyncio.CancelledError:
+                pass
+            return ConnFinishedReason.Shutdown
+
+    async def connect(self, transport: Transport) -> ConnFinishedReason:
+        """Connect to another peer as a client (outgoing connection).
+
+        This method initiates a connection to a peer and manages the full lifecycle:
+        - Dispatches a create_connection command to the Hub with Outgoing direction
+        - Stores the transport for sending messages
+        - Starts a receive loop to handle incoming messages
+        - Waits until the connection finishes (due to shutdown, disconnect, or error)
+
+        Use this method when your application is acting as a client initiating
+        the connection. For server-side connections (accepting incoming connections),
+        use accept() instead.
+
+        Args:
+            transport: The transport to use for communication
+
+        Returns:
+            The reason the connection finished
+
+        Example:
+            >>> # Client side
+            >>> transport = await WebSocketClientTransport.connect("ws://server:8080")
+            >>> await repo.connect(transport)
+        """
+        return await self._establish_connection(transport, ConnDirection.Outgoing)
+
+    async def accept(self, transport: Transport) -> ConnFinishedReason:
+        """Accept an incoming connection from a peer (server-side).
+
+        This method accepts a connection from a peer and manages the full lifecycle:
+        - Dispatches a create_connection command to the Hub with Incoming direction
+        - Stores the transport for sending messages
+        - Starts a receive loop to handle incoming messages
+        - Waits until the connection finishes (due to shutdown, disconnect, or error)
+
+        Use this method when your application is acting as a server accepting
+        incoming connections. For client-side connections (initiating connections),
+        use connect() instead.
+
+        Args:
+            transport: The transport to use for communication
+
+        Returns:
+            The reason the connection finished
+
+        Example:
+            >>> # Server side
+            >>> async def handle_connection(websocket):
+            ...     transport = WebSocketServerTransport(websocket)
+            ...     await repo.accept(transport)
+        """
+        return await self._establish_connection(transport, ConnDirection.Incoming)
+
+    async def create(self, doc: Optional[Dict[str, Any]] = None) -> "DocHandle":
+        """Create a new document in the repository.
+
+        Args:
+            doc: Optional initial document content (not yet supported)
+
+        Returns:
+            A handle to the created document
+        """
+        # Dispatch create_document command
+        command = HubEvent.create_document()
+        result = await self._dispatch_command(command)
+
+        # Result should be CommandResultCreateDocument
+        if not isinstance(result, CommandResultCreateDocument):
+            raise RuntimeError(f"Unexpected result type: {type(result)}")
+
+        # Return a handle to the document
+        return DocHandle(result.actor_id, result.document_id, self)
+
+    async def find(self, url: AutomergeUrl | str) -> Optional["DocHandle"]:
+        """Find an existing document by URL.
+
+        This method searches for a document by its URL. If the document exists
+        in this repository (either because it was created here or synced from
+        a peer), returns a handle to it. Otherwise returns None.
+
+        Args:
+            url: The document URL to find
+
+        Returns:
+            A handle to the document if found, None otherwise
+
+        Example:
+            >>> url = handle_a.url
+            >>> handle_b = await repo_b.find(url)
+            >>> if handle_b:
+            ...     print("Document found!")
+        """
+        document_id: DocumentId
+        if isinstance(url, str):
+            url2 = AutomergeUrl.from_str(url)
+            document_id = url2.document_id()
+        else:
+            # Extract document ID from URL
+            document_id = url.document_id()
+
+        # Dispatch find_document command
+        command = HubEvent.find_document(document_id)
+        result = await self._dispatch_command(command)
+
+        # Result should be CommandResultFindDocument
+        if not isinstance(result, CommandResultFindDocument):
+            raise RuntimeError(f"Unexpected result type: {type(result)}")
+
+        # If not found, return None
+        if not result.found:
+            return None
+
+        # Document was found - return a handle
+        return DocHandle(result.actor_id, document_id, self)
+
+
+class DocHandle:
+    """Handle to an Automerge document in the repository.
+
+    DocHandle provides access to a document managed by the repository.
+    It allows reading and modifying the document.
+    """
+
+    def __init__(self, actor_id: DocumentActorId, document_id: DocumentId, repo: Repo):
+        """Initialize a document handle.
+
+        Args:
+            actor_id: The document actor ID
+            document_id: The document ID
+            repo: The repository managing this document
+        """
+        self._actor_id = actor_id
+        self._document_id = document_id
+        self._repo = repo
+        self._event_callbacks: Dict[str, List[Callable]] = {}
+
+    @property
+    def url(self) -> AutomergeUrl:
+        """Get the document's URL.
+
+        Returns:
+            The AutomergeUrl for this document
+        """
+        return AutomergeUrl.from_document_id(self._document_id)
+
+    @property
+    def document_id(self) -> DocumentId:
+        """Get the document ID.
+
+        Returns:
+            The DocumentId
+        """
+        return self._document_id
+
+    def doc(self):
+        """Return a read-only view of the document.
+
+        The returned document proxy acquires a lock on each property access.
+        Nested accesses (e.g., doc["a"]["b"]["c"]) will acquire the lock
+        multiple times, once per level.
+
+        This document reference is read-only. Any attempt to modify it will
+        raise an exception. Use change() for mutations.
+
+        Returns:
+            MapReadProxy: A dict-like read-only view of the document
+
+        Example:
+            >>> doc = handle.doc()
+            >>> print(doc["content"])
+            >>> print(doc["nested"]["value"])
+
+        Note:
+            Each property access blocks while acquiring the document lock.
+            For write operations, use DocHandle.change() instead.
+        """
+        import automerge.core as core
+
+        from .document import MapReadProxy
+
+        # Get the document actor
+        actor = self._repo._doc_actors.get(self._actor_id)
+        if actor is None:
+            raise ValueError(f"Document actor {self._actor_id} not found")
+
+        # Get the actor-backed document
+        core_doc = actor.get_document()
+
+        # Wrap in MapReadProxy for Pythonic dict-like access
+        return MapReadProxy(core_doc, core.ROOT, None)
+
+    async def change(self, func: Callable[[Any], Any]) -> Any:
+        """Modify the document.
+
+        Args:
+            func: A function that takes a MapWriteProxy and modifies it
+
+        Returns:
+            The value returned by func
+
+        Example:
+            >>> def modify(doc):
+            ...     doc["key"] = "value"
+            >>> await handle.change(modify)
+        """
+        import time
+
+        import automerge.core as core
+
+        from .document import MapWriteProxy
+
+        # Get the document actor
+        actor = self._repo._doc_actors.get(self._actor_id)
+        if actor is None:
+            raise ValueError(f"Document actor {self._actor_id} not found")
+
+        # Wrap in transaction and MapWriteProxy
+        def wrapper(core_doc):
+            with core_doc.transaction() as tx:
+                proxy = MapWriteProxy(tx, core.ROOT, None)
+                return func(proxy)
+
+        # Call with_document - it will automatically capture patches
+        result = actor.with_document(time.time(), wrapper)
+
+        # Handle any IO tasks generated
+        for io_task in result.io_tasks:
+            asyncio.create_task(
+                self._repo._handle_doc_actor_io(self._actor_id, io_task)
+            )
+
+        # Handle outgoing messages
+        for msg in result.outgoing_messages:
+            await self._repo._hub_event_queue.put(
+                HubEvent.actor_message(self._actor_id, msg)
+            )
+
+        # Emit "change" event only if there were actual changes
+        if result.patches:
+            self._emit("change", result.patches)
+
+        return result.return_value
+
+    def on(self, event: str, callback: Callable) -> None:
+        """Register a callback for a document event.
+
+        Args:
+            event: The event name (currently only "change" is supported)
+            callback: The function to call when the event occurs.
+                     For "change" events, the callback receives a list of patches
+                     describing the changes made to the document.
+
+        Example:
+            >>> def on_change(patches):
+            ...     print(f"Document changed! {len(patches)} patches")
+            >>> handle.on("change", on_change)
+            >>> await handle.change(lambda doc: doc.put(ROOT, "key", "value"))
+            # Will print "Document changed! N patches"
+        """
+        if event not in self._event_callbacks:
+            self._event_callbacks[event] = []
+        self._event_callbacks[event].append(callback)
+
+    def off(self, event: str, callback: Callable) -> None:
+        """Remove a callback for a document event.
+
+        Args:
+            event: The event name
+            callback: The callback function to remove (must be the same object
+                     that was passed to on())
+
+        Example:
+            >>> def on_change(patches):
+            ...     print("Document changed!")
+            >>> handle.on("change", on_change)
+            >>> # Later, to remove the listener:
+            >>> handle.off("change", on_change)
+        """
+        if event in self._event_callbacks and callback in self._event_callbacks[event]:
+            self._event_callbacks[event].remove(callback)
+
+    def _emit(self, event: str, *args) -> None:
+        """Emit an event to all registered callbacks.
+
+        Args:
+            event: The event name to emit
+            *args: Arguments to pass to the callbacks
+        """
+        if event in self._event_callbacks:
+            for callback in self._event_callbacks[event]:
+                try:
+                    callback(*args)
+                except Exception as e:
+                    # Log the error but don't let it propagate
+                    # This prevents one bad callback from breaking others
+                    print(f"Error in {event} callback: {e}")
+
+    def __repr__(self) -> str:
+        return f"DocHandle(actor_id={self._actor_id}, document_id={self._document_id})"

--- a/src/automerge/repo.py
+++ b/src/automerge/repo.py
@@ -1303,6 +1303,93 @@ class Repo:
         return DocHandle(result.actor_id, document_id, self)
 
 
+class ChangeContext:
+    """Context manager for document modifications.
+
+    This class is returned by DocHandle.change() and provides a context manager
+    interface for modifying documents. Changes are committed when the context
+    exits normally, or rolled back if an exception is raised.
+
+    Example:
+        with handle.change() as doc:
+            doc["key"] = "value"
+            doc["count"] = 42
+
+    Note:
+        - Do not call `handle.doc()` inside the change block
+        - Do not nest change() calls
+    """
+
+    def __init__(self, handle: "DocHandle"):
+        """Initialize the change context.
+
+        Args:
+            handle: The DocHandle to modify
+        """
+        self._handle = handle
+        self._guard = None
+
+    def __enter__(self):
+        """Enter the change context and return a mutable document proxy.
+
+        Returns:
+            MapWriteProxy: A dict-like mutable view of the document
+        """
+        import automerge.core as core
+
+        from .document import MapWriteProxy
+
+        # Get the document actor
+        actor = self._handle._repo._doc_actors.get(self._handle._actor_id)
+        if actor is None:
+            raise ValueError(f"Document actor {self._handle._actor_id} not found")
+
+        # Begin the change - this acquires the mutex and creates a transaction
+        self._guard = actor.begin_change()
+        tx = self._guard.transaction()
+        return MapWriteProxy(tx, core.ROOT, None)
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Exit the change context, committing or rolling back.
+
+        Args:
+            exc_type: Exception type if an exception was raised, None otherwise
+            exc_val: Exception value if an exception was raised, None otherwise
+            exc_tb: Exception traceback if an exception was raised, None otherwise
+
+        Returns:
+            False (never suppress exceptions)
+        """
+        if self._guard is None:
+            return False
+
+        try:
+            commit = exc_type is None
+            result = self._guard.end_change(commit, time.time())
+
+            # Always process side effects - DocActorResult may contain effects
+            # even if the transaction was rolled back
+            for io_task in result.io_tasks:
+                asyncio.create_task(
+                    self._handle._repo._handle_doc_actor_io(
+                        self._handle._actor_id, io_task
+                    )
+                )
+
+            for msg in result.outgoing_messages:
+                self._handle._repo._hub_event_queue.put_nowait(
+                    HubEvent.actor_message(self._handle._actor_id, msg)
+                )
+
+            # Emit change event only if there were actual changes
+            if result.patches:
+                self._handle._emit("change", result.patches)
+        finally:
+            self._guard = None
+
+        return False  # Don't suppress exceptions
+
+
 class DocHandle:
     """Handle to an Automerge document in the repository.
 
@@ -1344,10 +1431,6 @@ class DocHandle:
     def doc(self):
         """Return a read-only view of the document.
 
-        The returned document proxy acquires a lock on each property access.
-        Nested accesses (e.g., doc["a"]["b"]["c"]) will acquire the lock
-        multiple times, once per level.
-
         This document reference is read-only. Any attempt to modify it will
         raise an exception. Use change() for mutations.
 
@@ -1378,57 +1461,23 @@ class DocHandle:
         # Wrap in MapReadProxy for Pythonic dict-like access
         return MapReadProxy(core_doc, core.ROOT, None)
 
-    async def change(self, func: Callable[[Any], Any]) -> Any:
-        """Modify the document.
-
-        Args:
-            func: A function that takes a MapWriteProxy and modifies it
-
-        Returns:
-            The value returned by func
+    def change(self) -> ChangeContext:
+        """Return a context manager for modifying the document.
 
         Example:
-            >>> def modify(doc):
-            ...     doc["key"] = "value"
-            >>> await handle.change(modify)
+            with handle.change() as doc:
+                doc["key"] = "value"
+                doc["count"] = 42
+
+        Note:
+            - Do not use `await` inside the change block
+            - Do not call `handle.doc()` inside the change block
+            - Do not nest change() calls
+
+        Returns:
+            ChangeContext: A context manager that provides mutable document access
         """
-        import time
-
-        import automerge.core as core
-
-        from .document import MapWriteProxy
-
-        # Get the document actor
-        actor = self._repo._doc_actors.get(self._actor_id)
-        if actor is None:
-            raise ValueError(f"Document actor {self._actor_id} not found")
-
-        # Wrap in transaction and MapWriteProxy
-        def wrapper(core_doc):
-            with core_doc.transaction() as tx:
-                proxy = MapWriteProxy(tx, core.ROOT, None)
-                return func(proxy)
-
-        # Call with_document - it will automatically capture patches
-        result = actor.with_document(time.time(), wrapper)
-
-        # Handle any IO tasks generated
-        for io_task in result.io_tasks:
-            asyncio.create_task(
-                self._repo._handle_doc_actor_io(self._actor_id, io_task)
-            )
-
-        # Handle outgoing messages
-        for msg in result.outgoing_messages:
-            await self._repo._hub_event_queue.put(
-                HubEvent.actor_message(self._actor_id, msg)
-            )
-
-        # Emit "change" event only if there were actual changes
-        if result.patches:
-            self._emit("change", result.patches)
-
-        return result.return_value
+        return ChangeContext(self)
 
     def on(self, event: str, callback: Callable) -> None:
         """Register a callback for a document event.
@@ -1443,7 +1492,8 @@ class DocHandle:
             >>> def on_change(patches):
             ...     print(f"Document changed! {len(patches)} patches")
             >>> handle.on("change", on_change)
-            >>> await handle.change(lambda doc: doc.put(ROOT, "key", "value"))
+            >>> with handle.change() as doc:
+            ...     doc["key"] = "value"
             # Will print "Document changed! N patches"
         """
         if event not in self._event_callbacks:

--- a/src/automerge/storages/__init__.py
+++ b/src/automerge/storages/__init__.py
@@ -1,0 +1,23 @@
+"""
+Storage adapters for automerge-py.
+
+This module provides storage implementations for persisting Automerge
+repository data. The core in-memory and filesystem storages are in repo.py,
+while cloud-specific storages are in this submodule.
+
+Available storages:
+    - S3Storage: Amazon S3 storage (requires aiobotocore)
+
+Example:
+    >>> from automerge.storages.s3 import S3Storage
+    >>> from automerge.repo import Repo
+    >>>
+    >>> storage = S3Storage(bucket="my-bucket", prefix="my-app")
+    >>> repo = await Repo.load(storage)
+"""
+
+from .s3 import S3Storage
+
+__all__ = ["S3Storage"]
+
+

--- a/src/automerge/storages/s3.py
+++ b/src/automerge/storages/s3.py
@@ -1,0 +1,262 @@
+"""
+S3 storage implementation for automerge-py.
+
+This module provides an S3-backed storage adapter that implements the Storage
+protocol required by automerge-py's Repo.load(). It uses aiobotocore for async
+S3 operations.
+
+Uses per-request client creation for automatic resource cleanup - no explicit
+close() call needed. Each operation manages its own S3 client connection.
+
+Requirements:
+    pip install automerge[s3]
+
+Example:
+    >>> from automerge.storages.s3 import S3Storage
+    >>> from automerge.repo import Repo
+    >>>
+    >>> storage = S3Storage(
+    ...     bucket="my-bucket",
+    ...     region="us-east-1",
+    ...     prefix="users/user-123"
+    ... )
+    >>> repo = await Repo.load(storage)
+    >>> async with repo:
+    ...     handle = await repo.create()
+    ...     with handle.change() as doc:
+    ...         doc["key"] = "value"
+"""
+
+import asyncio
+from typing import List, Optional, Tuple
+
+from aiobotocore.session import AioSession
+from botocore.exceptions import ClientError
+
+from automerge._automerge import StorageKey
+
+
+class S3Storage:
+    """
+    S3 storage implementation for automerge-py.
+
+    Implements the Storage protocol required by Repo.load() to persist
+    automerge documents in Amazon S3.
+
+    Uses per-request client creation for automatic resource cleanup.
+    No explicit close() call is needed - each operation manages its own
+    S3 client connection, similar to how the AWS SDK v3 for JavaScript works.
+
+    Attributes:
+        bucket: The S3 bucket name
+        region: The AWS region
+        prefix: Key prefix for all stored objects
+        credentials: Optional AWS credentials dict
+        endpoint_url: Optional custom endpoint URL for S3-compatible services
+        max_concurrent_requests: Concurrency limit for batch operations
+
+    Example:
+        >>> storage = S3Storage(
+        ...     bucket="my-bucket",
+        ...     region="us-east-1",
+        ...     prefix="users/user-123",
+        ... )
+        >>> repo = await Repo.load(storage)
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        region: str,
+        prefix: str = "",
+        credentials: Optional[dict] = None,
+        endpoint_url: Optional[str] = None,
+        max_concurrent_requests: int = 50,
+    ):
+        """
+        Initialize S3 storage.
+
+        Args:
+            bucket: S3 bucket name
+            region: AWS region (e.g., "us-east-1")
+            prefix: Key prefix for all stored objects (e.g., "users/user-123").
+                    This allows multiple users/repos to share a bucket.
+            credentials: Optional dict with AWS credentials:
+                - aws_access_key_id: AWS access key ID
+                - aws_secret_access_key: AWS secret access key
+                - aws_session_token: Optional session token for temporary credentials
+
+                If not provided, uses the default AWS credential chain
+                (environment variables, ~/.aws/credentials, IAM role, etc.)
+            endpoint_url: Optional custom endpoint URL for S3-compatible services
+                (e.g., "http://localhost:5000" for moto, "http://localhost:4566"
+                for LocalStack, or a MinIO URL). If not provided, uses the
+                default AWS S3 endpoint.
+            max_concurrent_requests: Maximum number of concurrent S3 requests
+                for batch operations like load_range(). Default: 50.
+        """
+        self.bucket = bucket
+        self.region = region
+        self.prefix = prefix.rstrip("/") if prefix else ""
+        self.credentials = credentials
+        self.endpoint_url = endpoint_url
+        self.max_concurrent_requests = max_concurrent_requests
+        self._session = AioSession()
+
+    def _create_client(self):
+        """
+        Create a new S3 client context manager.
+
+        Each call returns a fresh client context that should be used with
+        `async with`. The client is automatically cleaned up when the
+        context exits.
+
+        Returns:
+            An async context manager that yields an S3 client
+
+        Example:
+            async with self._create_client() as s3:
+                await s3.get_object(Bucket=self.bucket, Key=key)
+        """
+        kwargs = {
+            "region_name": self.region,
+        }
+
+        if self.endpoint_url:
+            kwargs["endpoint_url"] = self.endpoint_url
+
+        if self.credentials:
+            kwargs["aws_access_key_id"] = self.credentials.get("aws_access_key_id")
+            kwargs["aws_secret_access_key"] = self.credentials.get(
+                "aws_secret_access_key"
+            )
+            if self.credentials.get("aws_session_token"):
+                kwargs["aws_session_token"] = self.credentials.get("aws_session_token")
+
+        return self._session.create_client("s3", **kwargs)
+
+    def _storage_key_to_s3_key(self, key: StorageKey) -> str:
+        """
+        Convert a StorageKey to an S3 object key.
+
+        The StorageKey parts are joined with '/' to form a hierarchical path.
+        The configured prefix is prepended if set.
+
+        Args:
+            key: The StorageKey to convert
+
+        Returns:
+            S3 object key string
+        """
+        parts = key.to_parts()
+        path = "/".join(parts)
+        if self.prefix:
+            return f"{self.prefix}/{path}"
+        return path
+
+    def _s3_key_to_storage_key(self, s3_key: str) -> StorageKey:
+        """
+        Convert an S3 object key back to a StorageKey.
+
+        Strips the configured prefix if present and splits on '/'.
+
+        Args:
+            s3_key: S3 object key string
+
+        Returns:
+            StorageKey instance
+        """
+        # Strip prefix if present
+        if self.prefix and s3_key.startswith(self.prefix + "/"):
+            s3_key = s3_key[len(self.prefix) + 1 :]
+        parts = s3_key.split("/")
+        return StorageKey.from_parts(parts)
+
+    async def load(self, key: StorageKey) -> Optional[bytes]:
+        """
+        Load a value from S3.
+
+        Args:
+            key: The storage key to load
+
+        Returns:
+            The stored bytes if the key exists, None otherwise
+        """
+        s3_key = self._storage_key_to_s3_key(key)
+
+        async with self._create_client() as s3:
+            try:
+                response = await s3.get_object(Bucket=self.bucket, Key=s3_key)
+                return await response["Body"].read()
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "NoSuchKey":
+                    return None
+                raise
+
+    async def load_range(self, prefix: StorageKey) -> List[Tuple[StorageKey, bytes]]:
+        """
+        Load all keys with the given prefix from S3.
+
+        This lists all objects under the prefix path and loads each one
+        in parallel for better performance. Concurrency is limited by
+        max_concurrent_requests. Used by automerge-py to load all chunks
+        for a document.
+
+        Args:
+            prefix: The key prefix to match
+
+        Returns:
+            List of (key, value) tuples for all matching keys
+        """
+        s3_prefix = self._storage_key_to_s3_key(prefix) + "/"
+        sem = asyncio.Semaphore(self.max_concurrent_requests)
+
+        async with self._create_client() as s3:
+            # Collect all object keys first
+            object_keys: List[str] = []
+            paginator = s3.get_paginator("list_objects_v2")
+            async for page in paginator.paginate(Bucket=self.bucket, Prefix=s3_prefix):
+                for obj in page.get("Contents", []):
+                    object_keys.append(obj["Key"])
+
+            # Fetch all objects in parallel with limited concurrency
+            async def fetch_object(s3_key: str) -> Optional[Tuple[StorageKey, bytes]]:
+                async with sem:
+                    try:
+                        response = await s3.get_object(Bucket=self.bucket, Key=s3_key)
+                        data = await response["Body"].read()
+                        storage_key = self._s3_key_to_storage_key(s3_key)
+                        return (storage_key, data)
+                    except ClientError as e:
+                        # Skip objects that were deleted between list and get
+                        if e.response["Error"]["Code"] == "NoSuchKey":
+                            return None
+                        raise
+
+            fetched = await asyncio.gather(*[fetch_object(key) for key in object_keys])
+            return [item for item in fetched if item is not None]
+
+    async def put(self, key: StorageKey, value: bytes) -> None:
+        """
+        Store a value in S3.
+
+        Args:
+            key: The storage key
+            value: The bytes to store
+        """
+        s3_key = self._storage_key_to_s3_key(key)
+
+        async with self._create_client() as s3:
+            await s3.put_object(Bucket=self.bucket, Key=s3_key, Body=value)
+
+    async def delete(self, key: StorageKey) -> None:
+        """
+        Delete a value from S3.
+
+        Args:
+            key: The storage key to delete
+        """
+        s3_key = self._storage_key_to_s3_key(key)
+
+        async with self._create_client() as s3:
+            await s3.delete_object(Bucket=self.bucket, Key=s3_key)

--- a/src/automerge/transports/__init__.py
+++ b/src/automerge/transports/__init__.py
@@ -1,0 +1,35 @@
+"""Transport implementations for automerge-repo.
+
+This module provides transport implementations for syncing Automerge documents
+between repos. Transports handle the low-level communication between peers.
+
+Available transports:
+- InMemoryTransport: For testing and local communication (always available)
+- WebSocketClientTransport: Client-side WebSocket transport (requires websockets package)
+- WebSocketServerTransport: Server-side WebSocket transport (requires websockets package)
+- WebSocketServer: Helper for running a WebSocket server (requires websockets package)
+"""
+
+# Always available - no dependencies
+from .memory import InMemoryTransport
+
+__all__ = ["InMemoryTransport"]
+
+# WebSocket transports - optional dependency
+try:
+    from .websocket import (
+        WebSocketClientTransport,  # noqa
+        WebSocketServer,  # noqa
+        WebSocketServerTransport,  # noqa
+    )
+
+    __all__.extend(
+        [
+            "WebSocketClientTransport",
+            "WebSocketServerTransport",
+            "WebSocketServer",
+        ]
+    )
+except ImportError:
+    # websockets package not installed - that's okay, just don't export these
+    pass

--- a/src/automerge/transports/memory.py
+++ b/src/automerge/transports/memory.py
@@ -1,0 +1,77 @@
+"""In-memory transport for testing and local communication.
+
+This module provides InMemoryTransport, which allows two repos to communicate
+within the same process using asyncio queues. It's useful for testing and
+development scenarios.
+"""
+
+import asyncio
+from typing import Tuple
+
+
+class InMemoryTransport:
+    """In-memory transport for testing.
+
+    This transport allows two repos to communicate within the same process
+    using asyncio queues. Create a pair of transports using create_pair().
+    """
+
+    def __init__(self, send_queue: asyncio.Queue, recv_queue: asyncio.Queue):
+        """Initialize an in-memory transport.
+
+        Args:
+            send_queue: Queue to send messages to
+            recv_queue: Queue to receive messages from
+        """
+        self._send_queue = send_queue
+        self._recv_queue = recv_queue
+        self._closed = False
+
+    @classmethod
+    def create_pair(cls) -> Tuple["InMemoryTransport", "InMemoryTransport"]:
+        """Create a pair of connected transports.
+
+        Returns:
+            A tuple of (transport_a, transport_b) where messages sent on
+            transport_a are received on transport_b and vice versa.
+        """
+        queue_a_to_b = asyncio.Queue()
+        queue_b_to_a = asyncio.Queue()
+
+        transport_a = cls(queue_a_to_b, queue_b_to_a)
+        transport_b = cls(queue_b_to_a, queue_a_to_b)
+
+        return transport_a, transport_b
+
+    async def send(self, msg: bytes):
+        """Send a message to the peer.
+
+        Args:
+            msg: The message bytes to send
+
+        Raises:
+            RuntimeError: If the transport is closed
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+        await self._send_queue.put(msg)
+
+    async def recv(self) -> bytes:
+        """Receive a message from the peer.
+
+        Returns:
+            The received message bytes
+
+        Raises:
+            RuntimeError: If the transport is closed
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+        return await self._recv_queue.get()
+
+    async def close(self):
+        """Close the transport.
+
+        After closing, send() and recv() will raise RuntimeError.
+        """
+        self._closed = True

--- a/src/automerge/transports/websocket.py
+++ b/src/automerge/transports/websocket.py
@@ -1,0 +1,303 @@
+"""WebSocket transport implementations for automerge-repo.
+
+This module provides WebSocket-based transports for syncing Automerge documents
+over WebSocket connections. It requires the `websockets` package to be installed.
+
+Installation:
+    pip install automerge[websocket]
+
+Usage:
+    # Client side
+    transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+    await repo.connect(transport)
+
+    # Server side
+    async def handle_connection(websocket, path):
+        transport = WebSocketServerTransport(websocket)
+        await repo.accept(transport)
+
+    # Or use the WebSocketServer helper
+    async with WebSocketServer(repo, "localhost", 8080):
+        # Server is now running and accepting connections
+        await asyncio.sleep(3600)  # Keep server running
+"""
+
+# Import guard - provide helpful error message if websockets not installed
+try:
+    from websockets.client import WebSocketClientProtocol, connect
+    from websockets.exceptions import ConnectionClosed
+    from websockets.server import WebSocketServerProtocol, serve
+except ImportError as e:
+    raise ImportError(
+        "WebSocket transport requires the 'websockets' package. "
+        "Install it with: pip install automerge[websocket]"
+    ) from e
+
+import asyncio
+
+
+class WebSocketClientTransport:
+    """Client-side WebSocket transport.
+
+    This transport wraps a WebSocket client connection for use with automerge-repo.
+    Use the connect() classmethod to establish a connection.
+
+    Example:
+        >>> transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+        >>> await repo.connect(transport)
+    """
+
+    def __init__(self, websocket: WebSocketClientProtocol):
+        """Initialize a WebSocket client transport.
+
+        Args:
+            websocket: The connected WebSocket client protocol instance
+
+        Note:
+            Prefer using the connect() classmethod rather than calling this directly.
+        """
+        self._websocket = websocket
+        self._closed = False
+
+    @classmethod
+    async def connect(cls, uri: str) -> "WebSocketClientTransport":
+        """Connect to a WebSocket server.
+
+        Args:
+            uri: The WebSocket URI to connect to (e.g., "ws://localhost:8080")
+
+        Returns:
+            A connected WebSocketClientTransport instance
+
+        Example:
+            >>> transport = await WebSocketClientTransport.connect("ws://localhost:8080")
+            >>> await repo.connect(transport)
+        """
+        websocket = await connect(uri)
+        return cls(websocket)
+
+    async def send(self, msg: bytes):
+        """Send a message to the peer.
+
+        Args:
+            msg: The message bytes to send
+
+        Raises:
+            RuntimeError: If the transport is closed
+            TypeError: If the message is not bytes
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+
+        if not isinstance(msg, bytes):
+            raise TypeError(f"Message must be bytes, got {type(msg)}")
+
+        await self._websocket.send(msg)
+
+    async def recv(self) -> bytes:
+        """Receive a message from the peer.
+
+        Returns:
+            The received message bytes
+
+        Raises:
+            RuntimeError: If the transport is closed
+            TypeError: If the received message is not bytes
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+
+        try:
+            msg = await self._websocket.recv()
+        except ConnectionClosed:
+            # Connection closed - return empty bytes to signal EOF
+            self._closed = True
+            raise RuntimeError("Connection closed")
+
+        if not isinstance(msg, bytes):
+            raise TypeError(
+                f"Expected binary message, got {type(msg)}. "
+                "Ensure the WebSocket is configured for binary messages."
+            )
+
+        return msg
+
+    async def close(self):
+        """Close the WebSocket connection."""
+        if not self._closed:
+            self._closed = True
+            await self._websocket.close()
+
+    async def wait_closed(self):
+        """Wait for the WebSocket connection to be fully closed."""
+        await self._websocket.wait_closed()
+
+
+class WebSocketServerTransport:
+    """Server-side WebSocket transport.
+
+    This transport wraps a WebSocket server connection for use with automerge-repo.
+    Typically used within a WebSocket server handler function.
+
+    Example:
+        >>> async def handle_connection(websocket, path):
+        ...     transport = WebSocketServerTransport(websocket)
+        ...     await repo.accept(transport)
+    """
+
+    def __init__(self, websocket: WebSocketServerProtocol):
+        """Initialize a WebSocket server transport.
+
+        Args:
+            websocket: The WebSocket server protocol instance from the connection handler
+        """
+        self._websocket = websocket
+        self._closed = False
+
+    async def send(self, msg: bytes):
+        """Send a message to the peer.
+
+        Args:
+            msg: The message bytes to send
+
+        Raises:
+            RuntimeError: If the transport is closed
+            TypeError: If the message is not bytes
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+
+        if not isinstance(msg, bytes):
+            raise TypeError(f"Message must be bytes, got {type(msg)}")
+
+        await self._websocket.send(msg)
+
+    async def recv(self) -> bytes:
+        """Receive a message from the peer.
+
+        Returns:
+            The received message bytes. Returns empty bytes on EOF/connection close.
+
+        Raises:
+            RuntimeError: If the transport is closed
+            TypeError: If the received message is not bytes
+        """
+        if self._closed:
+            raise RuntimeError("Transport is closed")
+
+        try:
+            msg = await self._websocket.recv()
+        except ConnectionClosed:
+            # Connection closed - return empty bytes to signal EOF
+            self._closed = True
+            raise RuntimeError("Connection closed")
+
+        if not isinstance(msg, bytes):
+            raise TypeError(
+                f"Expected binary message, got {type(msg)}. "
+                "Ensure the WebSocket is configured for binary messages."
+            )
+
+        return msg
+
+    async def close(self):
+        """Close the WebSocket connection."""
+        if not self._closed:
+            self._closed = True
+            await self._websocket.close()
+
+    async def wait_closed(self):
+        """Wait for the WebSocket connection to be fully closed."""
+        await self._websocket.wait_closed()
+
+
+class WebSocketServer:
+    """Helper for running a WebSocket server for an automerge-repo.
+
+    This class manages a WebSocket server that automatically accepts connections
+    and handles them with the provided repository.
+
+    Example:
+        >>> repo = await Repo.load(storage)
+        >>> async with repo:
+        ...     async with WebSocketServer(repo, "localhost", 8080):
+        ...         # Server is now running
+        ...         await asyncio.sleep(3600)  # Keep server running
+    """
+
+    def __init__(self, repo, host: str = "localhost", port: int = 8080):
+        """Initialize a WebSocket server.
+
+        Args:
+            repo: The Repo instance to use for handling connections
+            host: The host to bind to (default: "localhost")
+            port: The port to bind to (default: 8080)
+        """
+        # Import here to avoid circular dependency
+        from automerge.repo import Repo
+
+        self._repo: Repo = repo
+        self._host = host
+        self._port = port
+        self._server = None
+        self._connections: set[asyncio.Task] = set()
+
+    async def _handle_connection(self, websocket, path):
+        """Handle a WebSocket connection.
+
+        Args:
+            websocket: The WebSocket connection
+            path: The request path (unused)
+        """
+        # Create transport and accept connection
+        transport = WebSocketServerTransport(websocket)
+
+        # Create task for this connection
+        task = asyncio.create_task(self._repo.accept(transport))
+        self._connections.add(task)
+
+        try:
+            # Wait for connection to finish
+            await task
+        finally:
+            # Clean up
+            self._connections.discard(task)
+
+    async def start(self):
+        """Start the WebSocket server.
+
+        This starts the server in the background. Use stop() to shut it down,
+        or use the context manager interface instead.
+        """
+        if self._server is not None:
+            raise RuntimeError("Server is already running")
+
+        self._server = await serve(self._handle_connection, self._host, self._port)
+
+    async def stop(self):
+        """Stop the WebSocket server.
+
+        This shuts down the server and waits for all active connections to close.
+        """
+        if self._server is None:
+            return
+
+        # Close the server (stop accepting new connections)
+        self._server.close()
+        await self._server.wait_closed()
+        self._server = None
+
+        # Wait for all active connections to finish
+        if self._connections:
+            await asyncio.gather(*self._connections, return_exceptions=True)
+        self._connections.clear()
+
+    async def __aenter__(self):
+        """Enter the async context manager - start the server."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit the async context manager - stop the server."""
+        await self.stop()
+        return False

--- a/tests/test_announce_policy.py
+++ b/tests/test_announce_policy.py
@@ -1,0 +1,403 @@
+"""Tests for announce policy functionality."""
+
+from __future__ import annotations
+
+import pytest
+
+from automerge.repo import InMemoryStorage, Repo
+
+
+class TestAnnouncePolicyLogic:
+    """Unit tests for announce policy logic."""
+
+    @pytest.mark.asyncio
+    async def test_default_policy_allows_all(self):
+        """Test that None policy (default) allows all documents."""
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage)
+
+        # Default policy should allow everything
+        result = await repo._check_announce_policy("doc-123", "peer-456")
+        assert result is True
+
+        result = await repo._check_announce_policy("any-doc", "any-peer")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_async_function_policy_allow(self):
+        """Test async function policy that allows documents."""
+
+        async def allow_all_policy(document_id: str, peer_id: str) -> bool:
+            return True
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=allow_all_policy)
+
+        result = await repo._check_announce_policy("doc-123", "peer-456")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_async_function_policy_deny(self):
+        """Test async function policy that denies documents."""
+
+        async def deny_all_policy(document_id: str, peer_id: str) -> bool:
+            return False
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=deny_all_policy)
+
+        result = await repo._check_announce_policy("doc-123", "peer-456")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_async_function_policy_selective(self):
+        """Test async function policy with conditional logic."""
+
+        async def selective_policy(document_id: str, peer_id: str) -> bool:
+            # Only allow documents starting with "public-"
+            return document_id.startswith("public-")
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=selective_policy)
+
+        # Should allow public documents
+        result = await repo._check_announce_policy("public-doc-1", "peer-1")
+        assert result is True
+
+        # Should deny private documents
+        result = await repo._check_announce_policy("private-doc-1", "peer-1")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_class_based_policy(self):
+        """Test class-based policy implementing AnnouncePolicy protocol."""
+
+        class TrustedPeerPolicy:
+            def __init__(self, trusted_peers: set[str]):
+                self.trusted_peers = trusted_peers
+
+            async def should_announce(self, document_id: str, peer_id: str) -> bool:
+                return peer_id in self.trusted_peers
+
+        policy = TrustedPeerPolicy({"peer-alice", "peer-bob"})
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=policy)
+
+        # Should allow trusted peers
+        result = await repo._check_announce_policy("doc-1", "peer-alice")
+        assert result is True
+
+        result = await repo._check_announce_policy("doc-1", "peer-bob")
+        assert result is True
+
+        # Should deny untrusted peers
+        result = await repo._check_announce_policy("doc-1", "peer-charlie")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_policy_error_handling_denies(self):
+        """Test that policy errors result in denial (fail closed)."""
+
+        async def broken_policy(document_id: str, peer_id: str) -> bool:
+            raise RuntimeError("Policy broke!")
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=broken_policy)
+
+        # Should deny on error (fail closed for security)
+        result = await repo._check_announce_policy("doc-1", "peer-1")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_class_policy_error_handling_denies(self):
+        """Test that class-based policy errors result in denial."""
+
+        class BrokenPolicy:
+            async def should_announce(self, document_id: str, peer_id: str) -> bool:
+                raise ValueError("Something went wrong")
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=BrokenPolicy())
+
+        # Should deny on error
+        result = await repo._check_announce_policy("doc-1", "peer-1")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_policy_with_state(self):
+        """Test that class-based policies can maintain state."""
+
+        class CountingPolicy:
+            def __init__(self):
+                self.check_count = 0
+
+            async def should_announce(self, document_id: str, peer_id: str) -> bool:
+                self.check_count += 1
+                return True
+
+        policy = CountingPolicy()
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=policy)
+
+        # Make several checks
+        await repo._check_announce_policy("doc-1", "peer-1")
+        await repo._check_announce_policy("doc-2", "peer-1")
+        await repo._check_announce_policy("doc-3", "peer-2")
+
+        # Verify state was maintained
+        assert policy.check_count == 3
+
+    @pytest.mark.asyncio
+    async def test_policy_receives_correct_parameters(self):
+        """Test that policy receives the correct document_id and peer_id."""
+        received_params = []
+
+        async def capture_policy(document_id: str, peer_id: str) -> bool:
+            received_params.append((document_id, peer_id))
+            return True
+
+        storage = InMemoryStorage()
+        repo = await Repo.load(storage, announce_policy=capture_policy)
+
+        await repo._check_announce_policy("test-doc", "test-peer")
+
+        assert len(received_params) == 1
+        assert received_params[0] == ("test-doc", "test-peer")
+
+
+class TestAnnouncePolicyIntegration:
+    """Integration tests for announce policy with document sync.
+
+    Note: These tests verify that the announce policy is consulted during
+    the document announcement flow. Full end-to-end sync testing is complex
+    due to timing and connection lifecycle issues.
+    """
+
+    @pytest.mark.asyncio
+    async def test_policy_consulted_on_connection(self):
+        """Test that announce policy is consulted when peers connect."""
+        import asyncio
+
+        from automerge.transports import InMemoryTransport
+
+        # Track policy calls
+        policy_calls = []
+
+        async def tracking_policy(document_id: str, peer_id: str) -> bool:
+            policy_calls.append((document_id, peer_id))
+            return True
+
+        # Create document BEFORE establishing connection
+        storage_a = InMemoryStorage()
+        repo_a = await Repo.load(storage_a, announce_policy=tracking_policy)
+
+        async with repo_a:
+            # Create a document
+            handle_a = await repo_a.create()
+
+            def init_doc(doc):
+                doc["message"] = "Test"
+
+            await handle_a.change(init_doc)
+
+            # Now connect to another repo
+            storage_b = InMemoryStorage()
+            repo_b = await Repo.load(storage_b)
+
+            async with repo_b:
+                transport_a, transport_b = InMemoryTransport.create_pair()
+
+                conn_task_a = asyncio.create_task(repo_a.connect(transport_a))
+                conn_task_b = asyncio.create_task(repo_b.accept(transport_b))
+
+                # Wait for connection and announce
+                await asyncio.sleep(1.0)
+
+                # Verify policy was called
+                assert len(policy_calls) >= 1, (
+                    "Policy should have been called when peer connected"
+                )
+
+                # Verify it was called for our document
+                doc_ids = [call[0] for call in policy_calls]
+                assert str(handle_a.document_id) in doc_ids, (
+                    "Policy should have been called for our document"
+                )
+
+                # Clean up
+                transport_a.close()
+                transport_b.close()
+                await asyncio.sleep(0.1)
+                conn_task_a.cancel()
+                conn_task_b.cancel()
+
+                try:
+                    await conn_task_a
+                except asyncio.CancelledError:
+                    pass
+
+                try:
+                    await conn_task_b
+                except asyncio.CancelledError:
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_policy_called_with_deny_result(self):
+        """Test that deny policy prevents document from being announced and synced."""
+        import asyncio
+
+        from automerge.transports import InMemoryTransport
+
+        # Track policy calls
+        policy_calls = []
+
+        async def deny_all_policy(document_id: str, peer_id: str) -> bool:
+            policy_calls.append((document_id, peer_id, False))
+            return False
+
+        # Create document in Repo A (with deny policy) BEFORE connection
+        storage_a = InMemoryStorage()
+        storage_b = InMemoryStorage()
+
+        repo_a = await Repo.load(storage_a, announce_policy=deny_all_policy)
+        repo_b = await Repo.load(storage_b)
+
+        async with repo_a, repo_b:
+            # Create document before connecting
+            handle_a = await repo_a.create()
+
+            def init_doc(doc):
+                doc["message"] = "Test document"
+
+            await handle_a.change(init_doc)
+
+            # Connect the repos
+            transport_a, transport_b = InMemoryTransport.create_pair()
+            conn_task_a = asyncio.create_task(repo_a.connect(transport_a))
+            conn_task_b = asyncio.create_task(repo_b.accept(transport_b))
+
+            # Wait for connection and policy check
+            await asyncio.sleep(1.0)
+
+            # Verify policy was called and returned False
+            assert len(policy_calls) >= 1, "Deny policy should have been called"
+            doc_ids = [call[0] for call in policy_calls]
+            assert str(handle_a.document_id) in doc_ids, (
+                "Policy should have been called for our document"
+            )
+
+            # Verify all calls returned False
+            results = [call[2] for call in policy_calls]
+            assert all(r is False for r in results), (
+                "All policy calls should have returned False"
+            )
+
+            # Disconnect the peers
+            conn_task_a.cancel()
+            conn_task_b.cancel()
+
+            try:
+                await conn_task_a
+            except asyncio.CancelledError:
+                pass
+
+            try:
+                await conn_task_b
+            except asyncio.CancelledError:
+                pass
+
+            transport_a.close()
+            transport_b.close()
+
+            # Wait for cleanup
+            await asyncio.sleep(0.5)
+
+            # Try to find the document - should NOT be available because it was not announced
+            handle_b = await asyncio.wait_for(repo_b.find(handle_a.url), timeout=2.0)
+            assert handle_b is None, (
+                "Document should not have been announced with deny policy"
+            )
+
+    @pytest.mark.asyncio
+    async def test_policy_called_with_allow_result(self):
+        """Test that allow policy allows document to be announced and synced."""
+        import asyncio
+
+        from automerge.transports import InMemoryTransport
+
+        # Track policy calls
+        policy_calls = []
+
+        async def allow_all_policy(document_id: str, peer_id: str) -> bool:
+            policy_calls.append((document_id, peer_id, True))
+            return True
+
+        # Create document in Repo A (with allow policy) BEFORE connection
+        storage_a = InMemoryStorage()
+        storage_b = InMemoryStorage()
+
+        repo_a = await Repo.load(storage_a, announce_policy=allow_all_policy)
+        repo_b = await Repo.load(storage_b)
+
+        async with repo_a, repo_b:
+            # Create document before connecting
+            handle_a = await repo_a.create()
+
+            def init_doc(doc):
+                doc["message"] = "Test document"
+
+            await handle_a.change(init_doc)
+
+            # Connect the repos
+            transport_a, transport_b = InMemoryTransport.create_pair()
+            conn_task_a = asyncio.create_task(repo_a.connect(transport_a))
+            conn_task_b = asyncio.create_task(repo_b.accept(transport_b))
+
+            # Wait for connection and policy check
+            await asyncio.sleep(1.0)
+
+            # Verify policy was called and returned True
+            assert len(policy_calls) >= 1, "Allow policy should have been called"
+            doc_ids = [call[0] for call in policy_calls]
+            assert str(handle_a.document_id) in doc_ids, (
+                "Policy should have been called for our document"
+            )
+
+            # Verify all calls returned True
+            results = [call[2] for call in policy_calls]
+            assert all(r is True for r in results), (
+                "All policy calls should have returned True"
+            )
+
+            # Disconnect the peers
+            conn_task_a.cancel()
+            conn_task_b.cancel()
+
+            try:
+                await conn_task_a
+            except asyncio.CancelledError:
+                pass
+
+            try:
+                await conn_task_b
+            except asyncio.CancelledError:
+                pass
+
+            transport_a.close()
+            transport_b.close()
+
+            # Wait for cleanup
+            await asyncio.sleep(0.5)
+
+            # Try to find the document - should be available because it was announced
+            handle_b = await asyncio.wait_for(repo_b.find(handle_a.url), timeout=2.0)
+            assert handle_b is not None, (
+                "Document should have been announced with allow policy"
+            )
+
+            # Verify the content was synced
+            doc_b = handle_b.doc()
+            message = doc_b.get("message")
+            assert message == "Test document", (
+                "Document content should have been synced"
+            )

--- a/tests/test_announce_policy.py
+++ b/tests/test_announce_policy.py
@@ -195,10 +195,8 @@ class TestAnnouncePolicyIntegration:
             # Create a document
             handle_a = await repo_a.create()
 
-            def init_doc(doc):
+            with handle_a.change() as doc:
                 doc["message"] = "Test"
-
-            await handle_a.change(init_doc)
 
             # Now connect to another repo
             storage_b = InMemoryStorage()
@@ -266,10 +264,8 @@ class TestAnnouncePolicyIntegration:
             # Create document before connecting
             handle_a = await repo_a.create()
 
-            def init_doc(doc):
+            with handle_a.change() as doc:
                 doc["message"] = "Test document"
-
-            await handle_a.change(init_doc)
 
             # Connect the repos
             transport_a, transport_b = InMemoryTransport.create_pair()
@@ -343,10 +339,8 @@ class TestAnnouncePolicyIntegration:
             # Create document before connecting
             handle_a = await repo_a.create()
 
-            def init_doc(doc):
+            with handle_a.change() as doc:
                 doc["message"] = "Test document"
-
-            await handle_a.change(init_doc)
 
             # Connect the repos
             transport_a, transport_b = InMemoryTransport.create_pair()

--- a/tests/test_connection_cleanup.py
+++ b/tests/test_connection_cleanup.py
@@ -1,0 +1,73 @@
+"""Minimal test to verify connection cleanup works correctly."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_connection_cleanup_with_deny_policy():
+    """Test that connection cleanup works correctly with announce policy.
+
+    This test verifies that when connections are cancelled and closed,
+    the Hub is properly notified so it stops emitting SendActions for
+    those connections.
+    """
+    import asyncio
+    from automerge.repo import Repo, InMemoryStorage
+    from automerge.transports import InMemoryTransport
+
+    # Add a deny-all policy to Repo A
+    async def deny_all_policy(document_id: str, peer_id: str) -> bool:
+        return False
+
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a, announce_policy=deny_all_policy)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        # Create a document in Repo A BEFORE connecting
+        handle_a = await repo_a.create()
+
+        def init_doc(doc):
+            doc["message"] = "Test document"
+
+        await handle_a.change(init_doc)
+
+        # Now create and connect transports
+        transport_a, transport_b = InMemoryTransport.create_pair()
+
+        conn_task_a = asyncio.create_task(repo_a.connect(transport_a))
+        conn_task_b = asyncio.create_task(repo_b.accept(transport_b))
+
+        # Wait for connection to establish and policy to be checked
+        await asyncio.sleep(1.0)
+
+        # Cancel connection tasks
+        conn_task_a.cancel()
+        conn_task_b.cancel()
+
+        try:
+            await conn_task_a
+        except asyncio.CancelledError:
+            pass
+
+        try:
+            await conn_task_b
+        except asyncio.CancelledError:
+            pass
+
+        # Close transports
+        transport_a.close()
+        transport_b.close()
+
+        # Wait for cleanup
+        await asyncio.sleep(0.5)
+
+        # Now call find() - this should NOT hang because the Hub was notified of disconnection
+        handle_b = await asyncio.wait_for(repo_b.find(handle_a.url), timeout=2.0)
+
+        # With deny policy, document should not have been announced
+        assert handle_b is None, (
+            "Document should not have been announced with deny policy"
+        )

--- a/tests/test_connection_cleanup.py
+++ b/tests/test_connection_cleanup.py
@@ -29,10 +29,8 @@ async def test_connection_cleanup_with_deny_policy():
         # Create a document in Repo A BEFORE connecting
         handle_a = await repo_a.create()
 
-        def init_doc(doc):
+        with handle_a.change() as doc:
             doc["message"] = "Test document"
-
-        await handle_a.change(init_doc)
 
         # Now create and connect transports
         transport_a, transport_b = InMemoryTransport.create_pair()

--- a/tests/test_filesystem_storage.py
+++ b/tests/test_filesystem_storage.py
@@ -1,0 +1,234 @@
+import pytest
+
+from automerge._automerge import StorageKey
+from automerge.repo import FileSystemStorage, Repo
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_put_and_load(tmp_path):
+    """Test basic put and load operations with FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+    key = StorageKey.from_parts(["test", "key"])
+    value = b"test data"
+
+    # Initially should be None
+    result = await storage.load(key)
+    assert result is None
+
+    # Put value
+    await storage.put(key, value)
+
+    # Should now load the value
+    result = await storage.load(key)
+    assert result == value
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_delete(tmp_path):
+    """Test delete operation with FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+    key = StorageKey.from_parts(["test", "delete"])
+    value = b"to be deleted"
+
+    # Put and verify
+    await storage.put(key, value)
+    assert await storage.load(key) == value
+
+    # Delete
+    await storage.delete(key)
+
+    # Should be None after delete
+    assert await storage.load(key) is None
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_load_range(tmp_path):
+    """Test load_range operation with FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Put multiple values with same prefix
+    await storage.put(StorageKey.from_parts(["docs", "doc1", "data"]), b"data1")
+    await storage.put(StorageKey.from_parts(["docs", "doc2", "data"]), b"data2")
+    await storage.put(StorageKey.from_parts(["docs", "doc3", "data"]), b"data3")
+    await storage.put(StorageKey.from_parts(["other", "key"]), b"other")
+
+    # Load range with "docs" prefix
+    results = await storage.load_range(StorageKey.from_parts(["docs"]))
+
+    # Should get 3 results, not the "other" key
+    assert len(results) == 3
+
+    # Check that all results have correct prefix
+    for key, value in results:
+        parts = key.to_parts()
+        assert parts[0] == "docs"
+        assert value.startswith(b"data")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_load_range_empty(tmp_path):
+    """Test load_range with no matching keys for FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Load range with non-existent prefix
+    results = await storage.load_range(StorageKey.from_parts(["nonexistent"]))
+
+    # Should get empty list
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_overwrite(tmp_path):
+    """Test overwriting an existing key with FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+    key = StorageKey.from_parts(["test", "overwrite"])
+
+    # Put initial value
+    await storage.put(key, b"initial")
+    assert await storage.load(key) == b"initial"
+
+    # Overwrite with new value
+    await storage.put(key, b"updated")
+    assert await storage.load(key) == b"updated"
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_splay(tmp_path):
+    """Test that FileSystemStorage correctly splays keys like git"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Key with long first component - should be splayed
+    key = StorageKey.from_parts(["abc123def", "data"])
+    await storage.put(key, b"test")
+
+    # Check the file structure: should be base/ab/c123def/data
+    expected_path = tmp_path / "storage" / "ab" / "c123def" / "data"
+    assert expected_path.exists()
+    assert expected_path.read_bytes() == b"test"
+
+    # Verify load works with splayed path
+    result = await storage.load(key)
+    assert result == b"test"
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_splay_short_key_error(tmp_path):
+    """Test FileSystemStorage raises error for short first component"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Key with very short first component should raise
+    key = StorageKey.from_parts(["a", "data"])
+    with pytest.raises(ValueError, match="at least 3 characters"):
+        await storage.put(key, b"short")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_splay_two_char_key_error(tmp_path):
+    """Test FileSystemStorage raises error for two-char first component"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Key with exactly 2 char first component should raise
+    key = StorageKey.from_parts(["ab", "data"])
+    with pytest.raises(ValueError, match="at least 3 characters"):
+        await storage.put(key, b"two-char")
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_delete_leaves_dirs(tmp_path):
+    """Test that delete removes file but leaves directories (for concurrency safety)"""
+    storage = FileSystemStorage(tmp_path / "storage")
+    key = StorageKey.from_parts(["abc123", "nested", "deep", "file"])
+
+    await storage.put(key, b"deep data")
+
+    # Verify the nested structure exists
+    nested_dir = tmp_path / "storage" / "ab" / "c123" / "nested" / "deep"
+    assert nested_dir.exists()
+
+    # Delete the file
+    await storage.delete(key)
+
+    # File should be gone
+    assert await storage.load(key) is None
+
+    # But directories remain (for concurrency safety)
+    assert nested_dir.exists()
+    assert (tmp_path / "storage").exists()
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_persistence(tmp_path):
+    """Test that FileSystemStorage persists data across instances"""
+    storage_path = tmp_path / "storage"
+    key = StorageKey.from_parts(["persist", "test"])
+    value = b"persistent data"
+
+    # Create first instance and store data
+    storage1 = FileSystemStorage(storage_path)
+    await storage1.put(key, value)
+
+    # Create second instance pointing to same path
+    storage2 = FileSystemStorage(storage_path)
+
+    # Data should be accessible from second instance
+    result = await storage2.load(key)
+    assert result == value
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_multiple_operations(tmp_path):
+    """Test multiple storage operations in sequence with FileSystemStorage"""
+    storage = FileSystemStorage(tmp_path / "storage")
+
+    # Create several keys
+    keys = [
+        StorageKey.from_parts(["app", "user", "1"]),
+        StorageKey.from_parts(["app", "user", "2"]),
+        StorageKey.from_parts(["app", "config"]),
+    ]
+
+    # Put values
+    for i, key in enumerate(keys):
+        await storage.put(key, f"value{i}".encode())
+
+    # Load and verify
+    for i, key in enumerate(keys):
+        value = await storage.load(key)
+        assert value == f"value{i}".encode()
+
+    # Load range
+    user_keys = await storage.load_range(StorageKey.from_parts(["app", "user"]))
+    assert len(user_keys) == 2
+
+    # Delete one
+    await storage.delete(keys[0])
+    assert await storage.load(keys[0]) is None
+    assert await storage.load(keys[1]) is not None
+
+
+@pytest.mark.asyncio
+async def test_filesystem_storage_with_repo(tmp_path):
+    """Test FileSystemStorage works with Repo"""
+    storage = FileSystemStorage(tmp_path / "repo_storage")
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        handle = await repo.create()
+        url = handle.url
+
+        # Make a change
+        await handle.change(lambda doc: doc.__setitem__("key", "value"))
+
+        # Verify the change
+        assert handle.doc()["key"] == "value"
+
+    # Data should be persisted - create new repo with same storage
+    storage2 = FileSystemStorage(tmp_path / "repo_storage")
+    repo2 = await Repo.load(storage2)
+
+    async with repo2:
+        # Find the document by URL
+        handle2 = await repo2.find(url)
+        assert handle2 is not None
+        assert handle2.doc()["key"] == "value"

--- a/tests/test_filesystem_storage.py
+++ b/tests/test_filesystem_storage.py
@@ -218,7 +218,8 @@ async def test_filesystem_storage_with_repo(tmp_path):
         url = handle.url
 
         # Make a change
-        await handle.change(lambda doc: doc.__setitem__("key", "value"))
+        with handle.change() as doc:
+            doc["key"] = "value"
 
         # Verify the change
         assert handle.doc()["key"] == "value"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,0 +1,2066 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from asyncio.queues import Queue
+
+import pytest
+
+from automerge._automerge import (
+    AutomergeUrl,
+    CheckAnnouncePolicyAction,
+    CheckAnnouncePolicyResultPayload,
+    CommandId,
+    ConnectionId,
+    ConnectionInfo,
+    ConnectionState,
+    DisconnectAction,
+    DisconnectResultPayload,
+    DocumentActorId,
+    DocumentId,
+    DocumentIoResultCheckAnnouncePolicy,
+    DocumentIoResultStorage,
+    Hub,
+    IoResult,
+    IoTaskId,
+    LoaderStateLoaded,
+    LoaderStateNeedIo,
+    PeerDocState,
+    PeerId,
+    SamodLoader,
+    SendAction,
+    SendResultPayload,
+    StorageId,
+    StorageKey,
+    StorageResult,
+    StorageResultPayload,
+    StorageTaskAction,
+    StorageTaskDelete,
+    StorageTaskLoad,
+    StorageTaskLoadRange,
+    StorageTaskPut,
+)
+from automerge.repo import InMemoryStorage, Repo
+from automerge.transports import InMemoryTransport
+
+
+def test_peer_id_creation():
+    """Test creating PeerId instances"""
+    # Create a random PeerId
+    peer1 = PeerId.random()
+    assert peer1 is not None
+    assert str(peer1).startswith("peer-")
+
+    # Create from string
+    peer2 = PeerId.from_string("peer-test")
+    assert str(peer2) == "peer-test"
+
+    # Test equality
+    peer3 = PeerId.from_string("peer-test")
+    assert peer2 == peer3
+
+    # Test inequality
+    assert peer1 != peer2
+
+    # Test repr
+    assert "PeerId" in repr(peer1)
+
+    # Test hash (for use in dicts/sets)
+    peer_set = {peer1, peer2}
+    assert len(peer_set) == 2
+
+
+def test_storage_id_creation():
+    """Test creating StorageId instances"""
+    # Create a random StorageId (UUID)
+    storage1 = StorageId.random()
+    assert storage1 is not None
+    # UUID format check (basic - just check it has hyphens)
+    assert "-" in str(storage1)
+
+    # Create from string
+    storage2 = StorageId.from_string("test-storage-id")
+    assert str(storage2) == "test-storage-id"
+
+    # Test equality
+    storage3 = StorageId.from_string("test-storage-id")
+    assert storage2 == storage3
+
+    # Test inequality
+    assert storage1 != storage2
+
+    # Test repr
+    assert "StorageId" in repr(storage1)
+
+    # Test hash
+    storage_set = {storage1, storage2}
+    assert len(storage_set) == 2
+
+
+def test_connection_id_creation():
+    """Test creating ConnectionId instances"""
+    # Create from u32
+    conn1 = ConnectionId.from_u32(42)
+    assert conn1.to_u32() == 42
+
+    # Test equality
+    conn2 = ConnectionId.from_u32(42)
+    assert conn1 == conn2
+
+    # Test inequality
+    conn3 = ConnectionId.from_u32(43)
+    assert conn1 != conn3
+
+    # Test repr
+    assert "ConnectionId" in repr(conn1)
+    assert "42" in repr(conn1)
+
+    # Test str
+    assert str(conn1) == "42"
+
+    # Test hash
+    conn_set = {conn1, conn3}
+    assert len(conn_set) == 2
+
+
+def test_document_actor_id_creation():
+    """Test creating DocumentActorId instances"""
+    # Create new DocumentActorId
+    actor1 = DocumentActorId.new()
+    assert actor1 is not None
+
+    # Create another to ensure they're different
+    actor2 = DocumentActorId.new()
+    assert actor1 != actor2
+
+    # Create from u32
+    actor3 = DocumentActorId.from_u32(100)
+    assert actor3.to_u32() == 100
+
+    # Test equality
+    actor4 = DocumentActorId.from_u32(100)
+    assert actor3 == actor4
+
+    # Test repr
+    assert "DocumentActorId" in repr(actor1)
+
+    # Test str (should be "actor:N" format)
+    assert "actor:" in str(actor3)
+
+    # Test hash
+    actor_set = {actor1, actor2, actor3}
+    assert len(actor_set) == 3
+
+
+def test_command_id_creation():
+    """Test creating CommandId instances"""
+    # Create from u32
+    cmd1 = CommandId.from_u32(1)
+    assert cmd1.to_u32() == 1
+
+    # Test equality
+    cmd2 = CommandId.from_u32(1)
+    assert cmd1 == cmd2
+
+    # Test inequality
+    cmd3 = CommandId.from_u32(2)
+    assert cmd1 != cmd3
+
+    # Test repr
+    assert "CommandId" in repr(cmd1)
+    assert "1" in repr(cmd1)
+
+    # Test str
+    assert str(cmd1) == "1"
+
+    # Test hash
+    cmd_set = {cmd1, cmd3}
+    assert len(cmd_set) == 2
+
+
+def test_document_id_creation():
+    """Test creating DocumentId instances"""
+    # Create DocumentId from a known UUID string (legacy format)
+    uuid_str = "550e8400-e29b-41d4-a716-446655440000"
+    doc1 = DocumentId.from_string(uuid_str)
+    assert doc1 is not None
+
+    # DocumentId should be base58 encoded when converted to string
+    doc1_str = str(doc1)
+    assert len(doc1_str) > 0
+
+    # Create from base58 string (round-trip)
+    doc2 = DocumentId.from_string(doc1_str)
+    assert doc1 == doc2
+    assert str(doc1) == str(doc2)
+
+    # Test bytes conversion
+    doc1_bytes = doc1.to_bytes()
+    assert len(doc1_bytes) == 16  # UUID is 16 bytes
+
+    # Test from_bytes (round-trip)
+    doc3 = DocumentId.from_bytes(list(doc1_bytes))
+    assert doc1 == doc3
+
+    # Test inequality with different UUID
+    uuid_str2 = "650e8400-e29b-41d4-a716-446655440000"
+    doc4 = DocumentId.from_string(uuid_str2)
+    assert doc1 != doc4
+
+    # Test repr
+    assert "DocumentId" in repr(doc1)
+
+    # Test hash
+    doc_set = {doc1, doc4}
+    assert len(doc_set) == 2
+
+    # Test invalid bytes length
+    try:
+        DocumentId.from_bytes([1, 2, 3])  # Too short
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass  # Expected
+
+
+def test_automerge_url_creation():
+    """Test creating AutomergeUrl instances"""
+    # Create a DocumentId for testing
+    doc_id = DocumentId.from_string("550e8400-e29b-41d4-a716-446655440000")
+    doc_id_str = str(doc_id)
+
+    # Create AutomergeUrl from string
+    url_str = f"automerge:{doc_id_str}"
+    url1 = AutomergeUrl.from_str(url_str)
+    assert url1 is not None
+
+    # Test to_str round-trip
+    assert url1.to_str() == url_str
+
+    # Test with path
+    url_with_path_str = f"automerge:{doc_id_str}/foo/bar"
+    url2 = AutomergeUrl.from_str(url_with_path_str)
+    assert url2.to_str() == url_with_path_str
+
+    # Test with numeric path component
+    url_with_index_str = f"automerge:{doc_id_str}/items/0"
+    url3 = AutomergeUrl.from_str(url_with_index_str)
+    assert url3.to_str() == url_with_index_str
+
+    # Test equality
+    url4 = AutomergeUrl.from_str(url_str)
+    assert url1 == url4
+
+    # Test inequality
+    assert url1 != url2
+
+    # Test repr
+    assert "AutomergeUrl" in repr(url1)
+
+    # Test str
+    assert str(url1) == url_str
+
+    # Test hash
+    url_set = {url1, url2}
+    assert len(url_set) == 2
+
+    # Test invalid URL
+    try:
+        AutomergeUrl.from_str("not-a-valid-url")
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass  # Expected
+
+
+def test_storage_key_creation():
+    """Test creating StorageKey instances"""
+    # Create from parts
+    key1 = StorageKey.from_parts(["users", "123", "profile"])
+    assert key1 is not None
+
+    # Test to_parts round-trip
+    parts = key1.to_parts()
+    assert parts == ["users", "123", "profile"]
+
+    # Test string representation (joined with "/")
+    assert str(key1) == "users/123/profile"
+
+    # Test equality
+    key2 = StorageKey.from_parts(["users", "123", "profile"])
+    assert key1 == key2
+
+    # Test inequality
+    key3 = StorageKey.from_parts(["users", "456", "profile"])
+    assert key1 != key3
+
+    # Test repr
+    assert "StorageKey" in repr(key1)
+
+    # Test hash
+    key_set = {key1, key3}
+    assert len(key_set) == 2
+
+    # Test empty parts not allowed
+    try:
+        StorageKey.from_parts(["users", "", "profile"])
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass  # Expected
+
+    # Test parts with "/" not allowed
+    try:
+        StorageKey.from_parts(["users/admins", "123"])
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass  # Expected
+
+
+def test_storage_task_load():
+    """Test creating Load StorageTask"""
+    key = StorageKey.from_parts(["document", "abc123", "data"])
+    task = StorageTaskLoad(key)
+
+    # Test isinstance checks (replacing is_* methods)
+    assert isinstance(task, StorageTaskLoad)
+    assert not isinstance(task, StorageTaskLoadRange)
+    assert not isinstance(task, StorageTaskPut)
+    assert not isinstance(task, StorageTaskDelete)
+
+    # Test direct field access (replacing key() method)
+    assert task.key.to_parts() == ["document", "abc123", "data"]
+
+    # Test repr
+    assert "Load" in repr(task)
+
+
+def test_storage_task_load_range():
+    """Test creating LoadRange StorageTask"""
+    prefix = StorageKey.from_parts(["document", "abc123"])
+    task = StorageTaskLoadRange(prefix)
+
+    # Test isinstance checks (replacing is_* methods)
+    assert not isinstance(task, StorageTaskLoad)
+    assert isinstance(task, StorageTaskLoadRange)
+    assert not isinstance(task, StorageTaskPut)
+    assert not isinstance(task, StorageTaskDelete)
+
+    # Test direct field access (replacing key() method)
+    assert task.prefix.to_parts() == ["document", "abc123"]
+
+    # Test repr
+    assert "LoadRange" in repr(task)
+
+
+def test_storage_task_put():
+    """Test creating Put StorageTask"""
+    key = StorageKey.from_parts(["document", "abc123", "snapshot"])
+    value = b"test data content"
+    task = StorageTaskPut(key, list(value))
+
+    # Test isinstance checks (replacing is_* methods)
+    assert not isinstance(task, StorageTaskLoad)
+    assert not isinstance(task, StorageTaskLoadRange)
+    assert isinstance(task, StorageTaskPut)
+    assert not isinstance(task, StorageTaskDelete)
+
+    # Test direct field access (replacing key() and value() methods)
+    assert task.key.to_parts() == ["document", "abc123", "snapshot"]
+    assert bytes(task.value) == value
+
+    # Test repr
+    assert "Put" in repr(task)
+    assert "bytes" in repr(task)
+
+
+def test_storage_task_delete():
+    """Test creating Delete StorageTask"""
+    key = StorageKey.from_parts(["document", "old123", "data"])
+    task = StorageTaskDelete(key)
+
+    # Test isinstance checks (replacing is_* methods)
+    assert not isinstance(task, StorageTaskLoad)
+    assert not isinstance(task, StorageTaskLoadRange)
+    assert not isinstance(task, StorageTaskPut)
+    assert isinstance(task, StorageTaskDelete)
+
+    # Test direct field access (replacing key() method)
+    assert task.key.to_parts() == ["document", "old123", "data"]
+
+    # Test repr
+    assert "Delete" in repr(task)
+
+
+def test_storage_result_load_with_value():
+    """Test creating Load StorageResult with a value"""
+    value = b"test data"
+    result = StorageResult.load(list(value))
+
+    # Test variant checks
+    assert result.is_load()
+    assert not result.is_load_range()
+    assert not result.is_put()
+    assert not result.is_delete()
+
+    # Test value accessor
+    loaded_value = result.load_value()
+    assert loaded_value is not None
+    assert bytes(loaded_value) == value
+
+    # Test load_range_values (should be None)
+    assert result.load_range_values() is None
+
+    # Test repr
+    assert "Load" in repr(result)
+    assert "bytes" in repr(result)
+
+
+def test_storage_result_load_not_found():
+    """Test creating Load StorageResult with None (key not found)"""
+    result = StorageResult.load(None)
+
+    # Test variant checks
+    assert result.is_load()
+
+    # Test value accessor (should be None)
+    assert result.load_value() is None
+
+    # Test repr
+    assert "Load" in repr(result)
+    assert "None" in repr(result)
+
+
+def test_storage_result_load_range():
+    """Test creating LoadRange StorageResult"""
+    key1 = StorageKey.from_parts(["doc", "abc", "v1"])
+    key2 = StorageKey.from_parts(["doc", "abc", "v2"])
+    value1 = b"data1"
+    value2 = b"data2"
+
+    # Create LoadRange result with list of tuples
+    result = StorageResult.load_range([(key1, list(value1)), (key2, list(value2))])
+
+    # Test variant checks
+    assert not result.is_load()
+    assert result.is_load_range()
+    assert not result.is_put()
+    assert not result.is_delete()
+
+    # Test load_range_values
+    values_dict = result.load_range_values()
+    assert values_dict is not None
+    assert len(values_dict) == 2
+
+    # Check that the values are in the dict
+    # Note: we can't directly access by PyStorageKey, but we can iterate
+    found_values = set()
+    for k, v in values_dict.items():
+        found_values.add(bytes(v))
+    assert value1 in found_values
+    assert value2 in found_values
+
+    # Test load_value (should be None)
+    assert result.load_value() is None
+
+    # Test repr
+    assert "LoadRange" in repr(result)
+    assert "2 entries" in repr(result)
+
+
+def test_storage_result_put():
+    """Test creating Put StorageResult"""
+    result = StorageResult.put()
+
+    # Test variant checks
+    assert not result.is_load()
+    assert not result.is_load_range()
+    assert result.is_put()
+    assert not result.is_delete()
+
+    # Test accessors (should be None)
+    assert result.load_value() is None
+    assert result.load_range_values() is None
+
+    # Test repr
+    assert "Put" in repr(result)
+
+
+def test_storage_result_delete():
+    """Test creating Delete StorageResult"""
+    result = StorageResult.delete()
+
+    # Test variant checks
+    assert not result.is_load()
+    assert not result.is_load_range()
+    assert not result.is_put()
+    assert result.is_delete()
+
+    # Test accessors (should be None)
+    assert result.load_value() is None
+    assert result.load_range_values() is None
+
+    # Test repr
+    assert "Delete" in repr(result)
+
+
+def test_io_task_id():
+    """Test creating IoTaskId"""
+    # Create from u32
+    task_id1 = IoTaskId.from_u32(42)
+    assert task_id1.to_u32() == 42
+
+    # Test equality
+    task_id2 = IoTaskId.from_u32(42)
+    assert task_id1 == task_id2
+
+    # Test inequality
+    task_id3 = IoTaskId.from_u32(43)
+    assert task_id1 != task_id3
+
+    # Test repr
+    assert "IoTaskId" in repr(task_id1)
+    assert "42" in repr(task_id1)
+
+    # Test str
+    assert str(task_id1) == "42"
+
+    # Test hash
+    task_id_set = {task_id1, task_id3}
+    assert len(task_id_set) == 2
+
+
+def test_io_task():
+    """Test IoTask type (created internally by Rust)"""
+    # IoTask instances are created internally by the Rust code and passed
+    # to Python. They contain an 'action' field which is one of:
+    # - StorageTaskAction (contains a StorageTask)
+    # - SendAction (contains connection_id and message bytes)
+    # - DisconnectAction (contains connection_id)
+    # - CheckAnnouncePolicyAction (contains peer_id)
+    #
+    # These types are tested through integration tests with actual
+    # loader/hub usage where IoTask instances are naturally created.
+    #
+    # For now, we just verify the types are importable.
+    assert StorageTaskAction is not None
+    assert SendAction is not None
+    assert DisconnectAction is not None
+    assert CheckAnnouncePolicyAction is not None
+
+
+def test_io_result():
+    """Test IoResult type (created internally by Rust)"""
+    # IoResult instances are created internally by the Rust code and passed
+    # to Python. They contain a 'payload' field which is one of:
+    # - StorageResultPayload (contains a StorageResult that can be consumed once)
+    # - SendResultPayload (empty - just indicates send completed)
+    # - DisconnectResultPayload (empty - just indicates disconnect completed)
+    # - CheckAnnouncePolicyResultPayload (contains should_announce boolean)
+    #
+    # These types are tested through integration tests with actual
+    # loader/hub usage where IoResult instances are naturally created.
+    #
+    # For now, we just verify the types are importable.
+    assert StorageResultPayload is not None
+    assert SendResultPayload is not None
+    assert DisconnectResultPayload is not None
+    assert CheckAnnouncePolicyResultPayload is not None
+
+
+# ===== InMemoryStorage Tests =====
+
+
+@pytest.mark.asyncio
+async def test_storage_put_and_load():
+    """Test basic put and load operations"""
+    storage = InMemoryStorage()
+    key = StorageKey.from_parts(["test", "key"])
+    value = b"test data"
+
+    # Initially should be None
+    result = await storage.load(key)
+    assert result is None
+
+    # Put value
+    await storage.put(key, value)
+
+    # Should now load the value
+    result = await storage.load(key)
+    assert result == value
+
+
+@pytest.mark.asyncio
+async def test_storage_delete():
+    """Test delete operation"""
+    storage = InMemoryStorage()
+    key = StorageKey.from_parts(["test", "delete"])
+    value = b"to be deleted"
+
+    # Put and verify
+    await storage.put(key, value)
+    assert await storage.load(key) == value
+
+    # Delete
+    await storage.delete(key)
+
+    # Should be None after delete
+    assert await storage.load(key) is None
+
+
+@pytest.mark.asyncio
+async def test_storage_load_range():
+    """Test load_range operation"""
+    storage = InMemoryStorage()
+
+    # Put multiple values with same prefix
+    await storage.put(StorageKey.from_parts(["docs", "doc1", "data"]), b"data1")
+    await storage.put(StorageKey.from_parts(["docs", "doc2", "data"]), b"data2")
+    await storage.put(StorageKey.from_parts(["docs", "doc3", "data"]), b"data3")
+    await storage.put(StorageKey.from_parts(["other", "key"]), b"other")
+
+    # Load range with "docs" prefix
+    results = await storage.load_range(StorageKey.from_parts(["docs"]))
+
+    # Should get 3 results, not the "other" key
+    assert len(results) == 3
+
+    # Check that all results have correct prefix
+    for key, value in results:
+        parts = key.to_parts()
+        assert parts[0] == "docs"
+        assert value.startswith(b"data")
+
+
+@pytest.mark.asyncio
+async def test_storage_load_range_empty():
+    """Test load_range with no matching keys"""
+    storage = InMemoryStorage()
+
+    # Load range with non-existent prefix
+    results = await storage.load_range(StorageKey.from_parts(["nonexistent"]))
+
+    # Should get empty list
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_storage_overwrite():
+    """Test overwriting an existing key"""
+    storage = InMemoryStorage()
+    key = StorageKey.from_parts(["test", "overwrite"])
+
+    # Put initial value
+    await storage.put(key, b"initial")
+    assert await storage.load(key) == b"initial"
+
+    # Overwrite with new value
+    await storage.put(key, b"updated")
+    assert await storage.load(key) == b"updated"
+
+
+@pytest.mark.asyncio
+async def test_storage_multiple_operations():
+    """Test multiple storage operations in sequence"""
+    storage = InMemoryStorage()
+
+    # Create several keys
+    keys = [
+        StorageKey.from_parts(["app", "user", "1"]),
+        StorageKey.from_parts(["app", "user", "2"]),
+        StorageKey.from_parts(["app", "config"]),
+    ]
+
+    # Put values
+    for i, key in enumerate(keys):
+        await storage.put(key, f"value{i}".encode())
+
+    # Load and verify
+    for i, key in enumerate(keys):
+        value = await storage.load(key)
+        assert value == f"value{i}".encode()
+
+    # Load range
+    user_keys = await storage.load_range(StorageKey.from_parts(["app", "user"]))
+    assert len(user_keys) == 2
+
+    # Delete one
+    await storage.delete(keys[0])
+    assert await storage.load(keys[0]) is None
+    assert await storage.load(keys[1]) is not None
+
+
+# ===== Loader Integration Tests =====
+
+
+@pytest.mark.asyncio
+async def test_loader_integration():
+    """Test complete loader lifecycle with InMemoryStorage"""
+    # Create storage and loader
+    storage = InMemoryStorage()
+    peer_id = PeerId.random()
+    loader = SamodLoader(peer_id)
+
+    # Step 1: Initial step should request loading storage ID
+    state = loader.step(time.time())
+    assert isinstance(state, LoaderStateNeedIo)
+    print(f"Initial state: {state}")
+
+    tasks = state.tasks
+    assert len(tasks) == 1
+
+    # Step 2: Execute IO tasks
+    for task in tasks:
+        print(f"Executing task: {task}")
+        action = task.action
+
+        # Should be a storage task action
+        assert isinstance(action, StorageTaskAction)
+        storage_task = action.task
+
+        # Execute the storage task - use isinstance to determine task type
+        if isinstance(storage_task, StorageTaskLoad):
+            print(f"  Loading key: {storage_task.key}")
+            value = await storage.load(storage_task.key)
+            result = StorageResult.load(list(value) if value else None)
+        elif isinstance(storage_task, StorageTaskPut):
+            print(f"  Putting key: {storage_task.key}, value: {storage_task.value}")
+            await storage.put(storage_task.key, bytes(storage_task.value))
+            result = StorageResult.put()
+        elif isinstance(storage_task, StorageTaskDelete):
+            print(f"  Deleting key: {storage_task.key}")
+            await storage.delete(storage_task.key)
+            result = StorageResult.delete()
+        elif isinstance(storage_task, StorageTaskLoadRange):
+            print(f"  Loading range: {storage_task.prefix}")
+            results = await storage.load_range(storage_task.prefix)
+            result = StorageResult.load_range([(k, list(v)) for k, v in results])
+        else:
+            raise ValueError("Unknown storage task type")
+
+        # Create IoResult and provide it to loader
+        io_result = IoResult.from_storage_result(task.task_id, result)
+        loader.provide_io_result(io_result)
+
+    # Step 3: Step again - should either need more IO or be loaded
+    state = loader.step(time.time())
+    print(f"Second state: {state}")
+
+    # If we need more IO, execute those tasks too
+    while isinstance(state, LoaderStateNeedIo):
+        tasks = state.tasks
+        print(f"Got {len(tasks)} more task(s)")
+
+        for task in tasks:
+            print(f"Executing task: {task}")
+            action = task.action
+            assert isinstance(action, StorageTaskAction)
+            storage_task = action.task
+
+            if isinstance(storage_task, StorageTaskLoad):
+                value = await storage.load(storage_task.key)
+                result = StorageResult.load(list(value) if value else None)
+            elif isinstance(storage_task, StorageTaskPut):
+                await storage.put(storage_task.key, bytes(storage_task.value))
+                result = StorageResult.put()
+            elif isinstance(storage_task, StorageTaskDelete):
+                await storage.delete(storage_task.key)
+                result = StorageResult.delete()
+            elif isinstance(storage_task, StorageTaskLoadRange):
+                results = await storage.load_range(storage_task.prefix)
+                result = StorageResult.load_range([(k, list(v)) for k, v in results])
+
+            io_result = IoResult.from_storage_result(task.task_id, result)
+            loader.provide_io_result(io_result)
+
+        state = loader.step(time.time())
+        print(f"Next state: {state}")
+
+    # Step 4: Should now be loaded with a Hub
+    assert isinstance(state, LoaderStateLoaded)
+    print("✓ Loader completed successfully")
+
+    hub = state.hub
+    assert isinstance(hub, Hub)
+    print(f"✓ Got Hub: {hub}")
+
+    # Verify storage ID was saved
+    storage_id_key = StorageKey.from_parts(["storage-adapter-id"])
+    storage_id_value = await storage.load(storage_id_key)
+    assert storage_id_value is not None
+    print(f"✓ Storage ID persisted: {storage_id_value.decode('utf-8')}")
+
+
+@pytest.mark.asyncio
+async def test_loader_with_existing_storage_id():
+    """Test loader when storage ID already exists"""
+    # Create storage with pre-existing storage ID
+    storage = InMemoryStorage()
+    storage_id_key = StorageKey.from_parts(["storage-adapter-id"])
+    await storage.put(storage_id_key, b"existing-storage-id")
+
+    # Create loader
+    peer_id = PeerId.random()
+    loader = SamodLoader(peer_id)
+
+    # Step and execute IO tasks
+    state = loader.step(time.time())
+    assert isinstance(state, LoaderStateNeedIo)
+
+    tasks = state.tasks
+    for task in tasks:
+        action = task.action
+        assert isinstance(action, StorageTaskAction)
+        storage_task = action.task
+
+        if isinstance(storage_task, StorageTaskLoad):
+            value = await storage.load(storage_task.key)
+            result = StorageResult.load(list(value) if value else None)
+            io_result = IoResult.from_storage_result(task.task_id, result)
+            loader.provide_io_result(io_result)
+
+    # Should load immediately since storage ID exists
+    state = loader.step(time.time())
+    assert isinstance(state, LoaderStateLoaded)
+
+    hub = state.hub
+    assert isinstance(hub, Hub)
+    print("✓ Loaded with existing storage ID")
+
+
+def test_hub_io_result():
+    """Test HubIoResult creation and type checking with subclasses"""
+    from automerge._automerge import (
+        HubIoResultDisconnect,
+        HubIoResultSend,
+        IoResult,
+        IoTaskId,
+    )
+
+    # Create Send result
+    send_result = HubIoResultSend()
+    assert isinstance(send_result, HubIoResultSend)
+    assert not isinstance(send_result, HubIoResultDisconnect)
+    print(f"✓ HubIoResultSend(): {send_result}")
+
+    # Create Disconnect result
+    disconnect_result = HubIoResultDisconnect()
+    assert isinstance(disconnect_result, HubIoResultDisconnect)
+    assert not isinstance(disconnect_result, HubIoResultSend)
+    print(f"✓ HubIoResultDisconnect(): {disconnect_result}")
+
+    # Create IoResult from HubIoResult
+    task_id = IoTaskId.from_u32(42)
+    io_result = IoResult.from_hub_result(task_id, send_result)
+    assert io_result.task_id.to_u32() == 42
+    print(f"✓ IoResult.from_hub_result(): {io_result}")
+
+
+def test_document_io_result():
+    """Test DocumentIoResult creation and type checking with subclasses"""
+    # Create CheckAnnouncePolicy result
+    announce_result = DocumentIoResultCheckAnnouncePolicy(True)
+    assert isinstance(announce_result, DocumentIoResultCheckAnnouncePolicy)
+    assert not isinstance(announce_result, DocumentIoResultStorage)
+    assert announce_result.should_announce
+    print(f"✓ DocumentIoResultCheckAnnouncePolicy(True): {announce_result}")
+
+    # Create Storage result
+    storage_result = StorageResult.put()
+    doc_result = DocumentIoResultStorage(storage_result)
+    assert isinstance(doc_result, DocumentIoResultStorage)
+    assert not isinstance(doc_result, DocumentIoResultCheckAnnouncePolicy)
+    # Access the stored storage_result field
+    assert doc_result.storage_result.is_put()
+    print(f"✓ DocumentIoResultStorage(): {doc_result}")
+
+    # Create IoResult from DocumentIoResult
+    task_id = IoTaskId.from_u32(43)
+    io_result = IoResult.from_document_result(task_id, doc_result)
+    assert io_result.task_id.to_u32() == 43
+    print(f"✓ IoResult.from_document_result(): {io_result}")
+
+    # Can reuse DocumentIoResult since it's cloneable now
+    io_result2 = IoResult.from_document_result(task_id, doc_result)
+    assert io_result2.task_id.to_u32() == 43
+    print("✓ DocumentIoResult is cloneable: can create multiple IoResults")
+
+
+class DummyTransport:
+    outbox: Queue
+    inbox: Queue
+
+    @staticmethod
+    def pair() -> tuple["DummyTransport", "DummyTransport"]:
+        a = DummyTransport()
+        b = DummyTransport()
+        a.inbox = b.outbox
+        b.inbox = a.outbox
+        return a, b
+
+    async def send(self, msg: bytes):
+        await self.outbox.put(msg)
+
+    async def recv(self) -> bytes:
+        return await self.inbox.get()
+
+
+@pytest.mark.asyncio
+async def test_repo_initialization():
+    """Test basic Repo initialization and context manager"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+
+    # Load the repo
+    repo = await Repo.load(storage)
+
+    # Test context manager
+    async with repo:
+        # Verify repo is initialized
+        assert repo._hub is not None
+        assert repo._hub_task is not None
+        assert not repo._shutdown_event.is_set()
+
+        # Check that Hub has correct properties
+        peer_id = repo._hub.peer_id()
+        assert peer_id is not None
+
+        storage_id = repo._hub.storage_id()
+        assert storage_id is not None
+
+        # Verify Hub is not stopped
+        assert not repo._hub.is_stopped()
+
+    # After exiting context, Hub should be stopped
+    # (checked implicitly by successful exit)
+
+
+@pytest.mark.asyncio
+async def test_repo_hub_loop_with_tick():
+    """Test that Hub loop processes tick events"""
+    import asyncio
+
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+
+    repo = await Repo.load(storage)
+    async with repo:
+        # Let the Hub loop run for a bit
+        await asyncio.sleep(0.3)
+
+        # Verify Hub is still running
+        assert repo._hub_task is not None
+        assert not repo._hub_task.done()
+        assert not repo._hub.is_stopped()
+
+    # Hub should have stopped cleanly
+
+
+@pytest.mark.asyncio
+async def test_repo_storage_persistence():
+    """Test that storage ID is persisted across repo instances"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+
+    # First repo instance
+    repo1 = await Repo.load(storage)
+    async with repo1:
+        storage_id_1 = repo1._hub.storage_id()
+        peer_id_1 = repo1._hub.peer_id()
+
+    # Second repo instance with same storage
+    repo2 = await Repo.load(storage)
+    async with repo2:
+        storage_id_2 = repo2._hub.storage_id()
+        peer_id_2 = repo2._hub.peer_id()
+
+    # Storage ID should be the same (persisted)
+    assert storage_id_1.to_string() == storage_id_2.to_string()
+
+    # Peer ID should be different (each repo has unique peer ID)
+    assert peer_id_1.to_string() != peer_id_2.to_string()
+
+
+@pytest.mark.asyncio
+async def test_repo_event_dispatch():
+    """Test dispatching events to Hub loop"""
+    import asyncio
+
+    from automerge._automerge import HubEvent
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+
+    repo = await Repo.load(storage)
+    async with repo:
+        # Send a tick event to the Hub
+        await repo._hub_event_queue.put(HubEvent.tick())
+
+        # Wait a bit for processing
+        await asyncio.sleep(0.1)
+
+        # Hub should still be running
+        assert not repo._hub.is_stopped()
+
+    # After exiting context, Hub should be stopped
+
+
+@pytest.mark.asyncio
+async def test_repo_create_document():
+    """Test creating a document in the repository"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a new document
+        doc_handle = await repo.create()
+
+        # Verify we got a DocHandle back
+        assert doc_handle is not None
+        assert hasattr(doc_handle, "url")
+        assert hasattr(doc_handle, "document_id")
+
+        # Verify the document actor was spawned
+        assert doc_handle._actor_id in repo._doc_actors
+        assert doc_handle._actor_id in repo._doc_actor_queues
+        assert doc_handle._actor_id in repo._doc_actor_tasks
+
+        # Verify the URL is valid
+        url = doc_handle.url
+        assert url is not None
+        assert "automerge:" in url.to_str()
+
+        # Give the document actor a moment to initialize
+        await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_repo_multiple_documents():
+    """Test creating multiple documents in the same repository"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create multiple documents
+        doc1 = await repo.create()
+        doc2 = await repo.create()
+        doc3 = await repo.create()
+
+        # Verify all documents have unique IDs
+        assert doc1.document_id != doc2.document_id
+        assert doc2.document_id != doc3.document_id
+        assert doc1.document_id != doc3.document_id
+
+        # Verify all documents have unique actor IDs
+        assert doc1._actor_id != doc2._actor_id
+        assert doc2._actor_id != doc3._actor_id
+        assert doc1._actor_id != doc3._actor_id
+
+        # Verify all actors are tracked
+        assert len(repo._doc_actors) == 3
+        assert len(repo._doc_actor_queues) == 3
+        assert len(repo._doc_actor_tasks) == 3
+
+        # Give actors a moment to initialize
+        await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_repo_document_modification():
+    """Test modifying a document using doc() and change() methods"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        doc_handle = await repo.create()
+
+        # Give the actor time to initialize
+        await asyncio.sleep(0.1)
+
+        # Test that doc() and change() methods exist
+        assert hasattr(doc_handle, "doc")
+        assert callable(doc_handle.doc)
+        assert hasattr(doc_handle, "change")
+        assert callable(doc_handle.change)
+
+        # Test modifying the document
+        # Put a value in the document
+        def set_value(doc):
+            doc["hello"] = "world"
+
+        await doc_handle.change(set_value)
+
+        # Give IO tasks time to process
+        await asyncio.sleep(0.1)
+
+        # Read the value back
+        doc = doc_handle.doc()
+        result = doc.get("hello")
+
+        # Verify the value was set correctly
+        assert result == "world"
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_basic():
+    """Test basic event emitter functionality - single callback"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations and patches
+        callback_count = []
+        received_patches = []
+
+        def on_change(patches):
+            callback_count.append(1)
+            received_patches.append(patches)
+
+        # Register callback
+        doc_handle.on("change", on_change)
+
+        # Modify the document
+        def set_value(doc):
+            doc["key"] = "value"
+
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        # Callback should have been invoked once
+        assert len(callback_count) == 1
+        # Patches should have been received
+        assert len(received_patches) == 1
+        assert len(received_patches[0]) > 0  # Should have at least one patch
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_multiple_callbacks():
+    """Test multiple callbacks on the same event"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback1_count = []
+        callback2_count = []
+        callback3_count = []
+
+        def on_change_1(patches):
+            callback1_count.append(1)
+
+        def on_change_2(patches):
+            callback2_count.append(1)
+
+        def on_change_3(patches):
+            callback3_count.append(1)
+
+        # Register multiple callbacks
+        doc_handle.on("change", on_change_1)
+        doc_handle.on("change", on_change_2)
+        doc_handle.on("change", on_change_3)
+
+        # Modify the document
+        def set_value(doc):
+            doc["key"] = "value"
+
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        # All callbacks should have been invoked
+        assert len(callback1_count) == 1
+        assert len(callback2_count) == 1
+        assert len(callback3_count) == 1
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_multiple_changes():
+    """Test that callbacks are invoked for each change"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback_count = []
+
+        def on_change(patches):
+            callback_count.append(1)
+
+        # Register callback
+        doc_handle.on("change", on_change)
+
+        # Make multiple changes
+        for i in range(5):
+
+            def set_value(doc, value=i):
+                doc[f"key{value}"] = f"value{value}"
+
+            await doc_handle.change(set_value)
+            await asyncio.sleep(0.05)
+
+        # Callback should have been invoked 5 times
+        assert len(callback_count) == 5
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_error_isolation():
+    """Test that errors in one callback don't affect others"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback1_count = []
+        callback3_count = []
+
+        def on_change_1(patches):
+            callback1_count.append(1)
+
+        def on_change_2_error(patches):
+            raise ValueError("Intentional error in callback")
+
+        def on_change_3(patches):
+            callback3_count.append(1)
+
+        # Register callbacks - middle one will error
+        doc_handle.on("change", on_change_1)
+        doc_handle.on("change", on_change_2_error)
+        doc_handle.on("change", on_change_3)
+
+        # Modify the document
+        def set_value(doc):
+            doc["key"] = "value"
+
+        # This should not raise an exception
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        # First and third callbacks should still have been invoked
+        assert len(callback1_count) == 1
+        assert len(callback3_count) == 1
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_no_callbacks():
+    """Test that changes work fine when no callbacks are registered"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Modify the document without any callbacks registered
+        def set_value(doc):
+            doc["key"] = "value"
+
+        # This should work fine
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        # Verify the value was set
+        doc = doc_handle.doc()
+        result = doc.get("key")
+        assert result == "value"
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_doc_method_no_emit():
+    """Test that doc() method (read-only) does not emit change events"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback_count = []
+
+        def on_change(patches):
+            callback_count.append(1)
+
+        # Register callback
+        doc_handle.on("change", on_change)
+
+        # First, make a change to verify callback works
+        def set_value(doc):
+            doc["key"] = "value"
+
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        assert len(callback_count) == 1
+
+        # Now use doc() to read (should not trigger callback)
+        doc = doc_handle.doc()
+        doc.get("key")
+        await asyncio.sleep(0.1)
+
+        # Callback count should still be 1 (not incremented)
+        assert len(callback_count) == 1
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_off():
+    """Test removing event listeners with off()"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback1_count = []
+        callback2_count = []
+
+        def on_change_1(patches):
+            callback1_count.append(1)
+
+        def on_change_2(patches):
+            callback2_count.append(1)
+
+        # Register both callbacks
+        doc_handle.on("change", on_change_1)
+        doc_handle.on("change", on_change_2)
+
+        # Make a change - both should be called
+        def set_value_1(doc):
+            doc["key1"] = "value1"
+
+        await doc_handle.change(set_value_1)
+        await asyncio.sleep(0.1)
+
+        assert len(callback1_count) == 1
+        assert len(callback2_count) == 1
+
+        # Remove first callback
+        doc_handle.off("change", on_change_1)
+
+        # Make another change - only second should be called
+        def set_value_2(doc):
+            doc["key2"] = "value2"
+
+        await doc_handle.change(set_value_2)
+        await asyncio.sleep(0.1)
+
+        # First callback should still be 1, second should be 2
+        assert len(callback1_count) == 1
+        assert len(callback2_count) == 2
+
+        # Remove second callback
+        doc_handle.off("change", on_change_2)
+
+        # Make another change - neither should be called
+        def set_value_3(doc):
+            doc["key3"] = "value3"
+
+        await doc_handle.change(set_value_3)
+        await asyncio.sleep(0.1)
+
+        # Both should still be at their previous counts
+        assert len(callback1_count) == 1
+        assert len(callback2_count) == 2
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_off_nonexistent():
+    """Test that removing a non-existent listener doesn't error"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        def on_change(patches):
+            pass
+
+        # Try to remove a callback that was never added - should not error
+        doc_handle.off("change", on_change)
+
+        # Try to remove from a non-existent event - should not error
+        doc_handle.off("nonexistent_event", on_change)
+
+
+@pytest.mark.asyncio
+async def test_document_event_emitter_no_change_no_emit():
+    """Test that change() without actual changes doesn't emit event"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Track callback invocations
+        callback_count = []
+
+        def on_change(patches):
+            callback_count.append(1)
+
+        # Register callback
+        doc_handle.on("change", on_change)
+
+        # Call change() but don't actually modify anything
+        def no_op(doc):
+            # Just read, don't modify
+            doc.get("nonexistent_key")
+
+        await doc_handle.change(no_op)
+        await asyncio.sleep(0.1)
+
+        # Callback should NOT have been invoked
+        assert len(callback_count) == 0
+
+        # Now make an actual change
+        def set_value(doc):
+            doc["key"] = "value"
+
+        await doc_handle.change(set_value)
+        await asyncio.sleep(0.1)
+
+        # Now callback should have been invoked once
+        assert len(callback_count) == 1
+
+
+@pytest.mark.asyncio
+async def test_hub_connections_empty():
+    """Test Hub.connections() returns empty list when no connections exist"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Get connections from the hub
+        connections = repo._hub.connections()
+
+        # Should be an empty list initially
+        assert isinstance(connections, list)
+        assert len(connections) == 0
+
+
+def test_connection_state_types():
+    """Test that ConnectionState, PeerDocState, and ConnectionInfo types are exposed"""
+    # Verify the types are importable
+    assert ConnectionState is not None
+    assert PeerDocState is not None
+    assert ConnectionInfo is not None
+
+    # Verify they have repr methods
+    # Note: We can't easily construct these types without going through the Hub,
+    # but we can verify they exist and are the right type
+    assert hasattr(ConnectionState, "__repr__")
+    assert hasattr(PeerDocState, "__repr__")
+    assert hasattr(ConnectionInfo, "__repr__")
+
+
+@pytest.mark.asyncio
+async def test_repo_find_document():
+    """Test finding a document by URL"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        handle_a = await repo.create()
+
+        # Set some content
+        def init_doc(doc):
+            doc["test"] = "value"
+
+        await handle_a.change(init_doc)
+
+        # Get the URL
+        url = handle_a.url
+
+        # Find the document by URL
+        handle_b = await repo.find(url)
+
+        # Should find the document
+        assert handle_b is not None
+        assert handle_b.document_id == handle_a.document_id
+        assert handle_b.url == url
+
+        # Verify we can read the content through the new handle using new direct access API
+        doc = handle_b.doc()
+        result = doc["test"]
+        assert result == "value"
+
+        # TODO: Add test for non-existent document once find() properly handles this case
+        # Currently the command may hang if the document doesn't exist
+
+
+@pytest.mark.asyncio
+async def test_document_sync_basic():
+    """Test basic document synchronization between two repos"""
+    import asyncio
+
+    from automerge.repo import InMemoryStorage
+
+    # Create two repos with separate storage
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        # Create paired transports
+        transport_a, transport_b = InMemoryTransport.create_pair()
+
+        # Connect the repos - Repo A initiates (client), Repo B accepts (server)
+        conn_task_a = asyncio.create_task(repo_a.connect(transport_a))
+        conn_task_b = asyncio.create_task(repo_b.accept(transport_b))
+
+        # Give some time for handshake to complete
+        await asyncio.sleep(1.0)  # Increased from 0.3 to allow full handshake
+
+        # Now create a document in Repo A (after connections are established)
+        handle_a = await repo_a.create()
+
+        # Set some initial content
+        def init_doc(doc):
+            doc["title"] = "Hello from Repo A"
+            doc["count"] = 42
+
+        await handle_a.change(init_doc)
+
+        # Give time for the document to sync to Repo B
+        await asyncio.sleep(0.5)
+
+        # Verify connections exist
+        connections_a = repo_a._hub.connections()
+        connections_b = repo_b._hub.connections()
+
+        assert len(connections_a) >= 1, "Repo A should have at least one connection"
+        assert len(connections_b) >= 1, "Repo B should have at least one connection"
+
+        # The document should have synced from Repo A to Repo B
+        url = handle_a.url
+        handle_b = await repo_b.find(url)
+
+        assert handle_b is not None, "Document should have synced from Repo A to Repo B"
+        assert handle_b.document_id == handle_a.document_id
+
+        # Verify we can read the content from Repo B using new direct access API
+        doc = handle_b.doc()
+        result = doc["title"]
+        assert result == "Hello from Repo A", "Document content should have synced"
+
+        # Clean up - close transports to trigger disconnection
+        await transport_a.close()
+        await transport_b.close()
+
+        # Wait a bit for disconnection to complete
+        await asyncio.sleep(0.2)
+
+        # Cancel connection tasks
+        conn_task_a.cancel()
+        conn_task_b.cancel()
+
+        try:
+            await conn_task_a
+        except asyncio.CancelledError:
+            pass
+
+        try:
+            await conn_task_b
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_doc_direct_access_read_only():
+    """Test that documents from doc() are read-only and error on write attempts"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        doc_handle = await repo.create()
+
+        # Initialize with some content
+        def init_doc(doc):
+            doc["key"] = "value"
+
+        await doc_handle.change(init_doc)
+        await asyncio.sleep(0.1)
+
+        # Get read-only document reference
+        doc = doc_handle.doc()
+
+        # Verify we can read
+        assert doc["key"] == "value"
+
+        # Attempt to write - should raise error
+        with pytest.raises(TypeError) as exc_info:
+            doc["key"] = "new value"
+
+        # Error message should indicate item assignment is not supported
+        error_msg = str(exc_info.value)
+        assert (
+            "does not support item assignment" in error_msg or "read-only" in error_msg
+        )
+
+
+@pytest.mark.asyncio
+async def test_doc_direct_access_transaction_error():
+    """Test that creating transactions on actor-backed documents raises clear error"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        doc_handle = await repo.create()
+        await asyncio.sleep(0.1)
+
+        # Get the underlying core document
+        actor = repo._doc_actors.get(doc_handle._actor_id)
+        assert actor is not None
+
+        core_doc = actor.get_document()
+
+        # Attempt to create transaction - should raise error
+        with pytest.raises(Exception) as exc_info:
+            core_doc.transaction()
+
+        # Error message should mention DocHandle.change() as the alternative
+        error_msg = str(exc_info.value)
+        assert "read-only" in error_msg or "Cannot create transaction" in error_msg
+        assert "change()" in error_msg or "Use DocHandle.change()" in error_msg
+
+
+@pytest.mark.asyncio
+async def test_doc_concurrent_references():
+    """Test that multiple document references work concurrently"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document with some content
+        doc_handle = await repo.create()
+
+        def init_doc(doc):
+            doc["key1"] = "value1"
+            doc["key2"] = "value2"
+
+        await doc_handle.change(init_doc)
+        await asyncio.sleep(0.1)
+
+        # Get multiple document references
+        doc1 = doc_handle.doc()
+        doc2 = doc_handle.doc()
+        doc3 = doc_handle.doc()
+
+        # All should be able to read independently
+        assert doc1["key1"] == "value1"
+        assert doc2["key2"] == "value2"
+        assert doc3["key1"] == "value1"
+
+        # References should work independently (not interfere with each other)
+        result1 = doc1.get("key1")
+        result2 = doc2.get("key2")
+        result3 = doc3.get("key1")
+
+        assert result1 == "value1"
+        assert result2 == "value2"
+        assert result3 == "value1"
+
+
+@pytest.mark.asyncio
+async def test_doc_read_during_change():
+    """Test that reading while a change is in progress works correctly"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document with initial content
+        doc_handle = await repo.create()
+
+        def init_doc(doc):
+            doc["counter"] = 0
+
+        await doc_handle.change(init_doc)
+        await asyncio.sleep(0.1)
+
+        # Get initial document reference
+        doc_before = doc_handle.doc()
+        assert doc_before["counter"] == 0
+
+        # Make a change
+        def increment(doc):
+            doc["counter"] = 1
+
+        await doc_handle.change(increment)
+        await asyncio.sleep(0.1)
+
+        # Get new document reference after change
+        doc_after = doc_handle.doc()
+        assert doc_after["counter"] == 1
+
+        # Old reference should still work (it will see new state due to mutex)
+        # The mutex ensures we get a consistent view
+        current_value = doc_before["counter"]
+        assert current_value == 1  # Should see the updated value
+
+
+@pytest.mark.asyncio
+async def test_doc_reference_across_awaits():
+    """Test that document references stay valid across awaits"""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Create a document
+        doc_handle = await repo.create()
+
+        def init_doc(doc):
+            doc["field1"] = "value1"
+            doc["field2"] = "value2"
+
+        await doc_handle.change(init_doc)
+        await asyncio.sleep(0.1)
+
+        # Get document reference
+        doc = doc_handle.doc()
+
+        # Read value
+        val1 = doc["field1"]
+        assert val1 == "value1"
+
+        # Await something
+        await asyncio.sleep(0.05)
+
+        # Document reference should still be valid
+        val2 = doc["field2"]
+        assert val2 == "value2"
+
+        # Another await
+        await asyncio.sleep(0.05)
+
+        # Still valid
+        val1_again = doc.get("field1")
+        assert val1_again == "value1"
+
+        # Make a change via handle
+        def update(doc):
+            doc["field3"] = "value3"
+
+        await doc_handle.change(update)
+        await asyncio.sleep(0.1)
+
+        # Original reference should see the new value (mutex provides consistent view)
+        val3 = doc.get("field3")
+        assert val3 == "value3"
+
+
+@pytest.mark.asyncio
+async def test_doc_reference_in_change_callback():
+    """Test that doc() references work inside change() callbacks without deadlock."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Set up initial state
+        def init_counter(doc):
+            doc["counter"] = 0
+
+        await handle.change(init_counter)
+        await asyncio.sleep(0.1)
+
+        # Get a doc reference
+        doc_ref = handle.doc()
+
+        # Use the doc reference inside a change callback
+        # This should NOT deadlock
+        def increment_using_ref(doc):
+            doc["counter"] = doc_ref["counter"] + 1
+
+        await handle.change(increment_using_ref)
+        await asyncio.sleep(0.1)
+
+        # Verify the change worked
+        doc = handle.doc()
+        assert doc["counter"] == 1
+
+
+@pytest.mark.asyncio
+async def test_nested_doc_reference_in_change():
+    """Test that nested doc() references work in change callbacks."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Set up initial values
+        def init_values(doc):
+            doc["value1"] = 10
+            doc["value2"] = 20
+
+        await handle.change(init_values)
+        await asyncio.sleep(0.1)
+
+        # Get a doc reference
+        doc_ref = handle.doc()
+
+        # Use doc reference to read multiple values in change callback
+        def compute_sum(doc):
+            # Read from external doc reference
+            val1 = doc_ref["value1"]
+            val2 = doc_ref["value2"]
+            # Write to current doc
+            doc["sum"] = val1 + val2
+
+        await handle.change(compute_sum)
+        await asyncio.sleep(0.1)
+
+        # Verify
+        doc = handle.doc()
+        assert doc["sum"] == 30
+
+
+@pytest.mark.asyncio
+async def test_different_doc_in_change_callback():
+    """Test that accessing different document's reference works in change callback."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle1 = await repo.create()
+        handle2 = await repo.create()
+
+        # Set up both documents
+        def init_doc1(doc):
+            doc["name"] = "doc1"
+
+        await handle1.change(init_doc1)
+        await asyncio.sleep(0.1)
+
+        def init_doc2(doc):
+            doc["name"] = "doc2"
+
+        await handle2.change(init_doc2)
+        await asyncio.sleep(0.1)
+
+        # Get reference to doc2
+        doc2_ref = handle2.doc()
+
+        # Access doc2_ref inside doc1's change callback
+        # This should work because they're different actors
+        def use_doc2_ref(doc):
+            doc["other_name"] = doc2_ref["name"]
+
+        await handle1.change(use_doc2_ref)
+        await asyncio.sleep(0.1)
+
+        # Verify
+        doc1 = handle1.doc()
+        assert doc1["other_name"] == "doc2"
+
+
+@pytest.mark.asyncio
+async def test_multiple_doc_refs_in_change():
+    """Test that multiple doc() references work in change callback."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Set up state
+        def init_values(doc):
+            doc["a"] = 1
+            doc["b"] = 2
+
+        await handle.change(init_values)
+        await asyncio.sleep(0.1)
+
+        # Get multiple references (simulating user having refs from different places)
+        ref1 = handle.doc()
+        ref2 = handle.doc()
+
+        # Use both in change callback
+        def compute_sum(doc):
+            doc["sum"] = ref1["a"] + ref2["b"]
+
+        await handle.change(compute_sum)
+        await asyncio.sleep(0.1)
+
+        # Verify
+        doc = handle.doc()
+        assert doc["sum"] == 3
+
+
+@pytest.mark.asyncio
+async def test_nested_change_detection():
+    """Test that we can detect when we're in a change callback.
+
+    Note: Truly nested change() calls (calling change from within a change callback
+    on the same thread) will be detected and raise an error. This test verifies
+    the detection mechanism works.
+    """
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle1 = await repo.create()
+        handle2 = await repo.create()
+
+        # Set up initial state
+        def init_value(doc):
+            doc["value"] = 1
+
+        await handle1.change(init_value)
+        await handle2.change(init_value)
+        await asyncio.sleep(0.1)
+
+        # Test that we can access handle1.doc() from within handle2's change callback
+        # These are different actors, so this should work fine
+        def use_other_doc(doc):
+            # Access doc from handle1 while in handle2's change callback
+            val = handle1.doc()["value"]
+            doc["copied_value"] = val
+
+        await handle2.change(use_other_doc)
+        await asyncio.sleep(0.1)
+
+        # Verify it worked
+        doc2 = handle2.doc()
+        assert doc2["copied_value"] == 1
+
+
+@pytest.mark.asyncio
+async def test_context_cleanup_on_error():
+    """Test that context is cleaned up when callback raises error."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Set up state
+        def init_value(doc):
+            doc["value"] = 1
+
+        await handle.change(init_value)
+        await asyncio.sleep(0.1)
+
+        # Callback that raises an error
+        with pytest.raises(ValueError):
+
+            def error_callback(doc):
+                # Access doc() ref to set context, then raise error
+                _ = handle.doc()["value"]
+                raise ValueError("Intentional error")
+
+            await handle.change(error_callback)
+
+        await asyncio.sleep(0.1)
+
+        # Context should be cleaned up - next change should work
+        def update_value(doc):
+            doc["value"] = 2
+
+        await handle.change(update_value)
+        await asyncio.sleep(0.1)
+
+        # Verify subsequent operations work
+        doc = handle.doc()
+        assert doc["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_context_cleanup_after_success():
+    """Test that context is cleaned up after successful callback."""
+    from automerge.repo import InMemoryStorage
+
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # First change
+        def first_change(doc):
+            doc["value"] = 1
+
+        await handle.change(first_change)
+        await asyncio.sleep(0.1)
+
+        # Context should be cleared after first change completes
+        # Second change should not see it as "nested"
+        def second_change(doc):
+            doc["value"] = 2
+
+        await handle.change(second_change)
+        await asyncio.sleep(0.1)
+
+        # Verify
+        doc = handle.doc()
+        assert doc["value"] == 2

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1092,10 +1092,8 @@ async def test_repo_document_modification():
 
         # Test modifying the document
         # Put a value in the document
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["hello"] = "world"
-
-        await doc_handle.change(set_value)
 
         # Give IO tasks time to process
         await asyncio.sleep(0.1)
@@ -1132,10 +1130,8 @@ async def test_document_event_emitter_basic():
         doc_handle.on("change", on_change)
 
         # Modify the document
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
-
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         # Callback should have been invoked once
@@ -1177,10 +1173,8 @@ async def test_document_event_emitter_multiple_callbacks():
         doc_handle.on("change", on_change_3)
 
         # Modify the document
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
-
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         # All callbacks should have been invoked
@@ -1212,11 +1206,8 @@ async def test_document_event_emitter_multiple_changes():
 
         # Make multiple changes
         for i in range(5):
-
-            def set_value(doc, value=i):
-                doc[f"key{value}"] = f"value{value}"
-
-            await doc_handle.change(set_value)
+            with doc_handle.change() as doc:
+                doc[f"key{i}"] = f"value{i}"
             await asyncio.sleep(0.05)
 
         # Callback should have been invoked 5 times
@@ -1254,11 +1245,10 @@ async def test_document_event_emitter_error_isolation():
         doc_handle.on("change", on_change_3)
 
         # Modify the document
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
 
         # This should not raise an exception
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         # First and third callbacks should still have been invoked
@@ -1279,11 +1269,10 @@ async def test_document_event_emitter_no_callbacks():
         await asyncio.sleep(0.1)
 
         # Modify the document without any callbacks registered
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
 
         # This should work fine
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         # Verify the value was set
@@ -1314,10 +1303,8 @@ async def test_document_event_emitter_doc_method_no_emit():
         doc_handle.on("change", on_change)
 
         # First, make a change to verify callback works
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
-
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         assert len(callback_count) == 1
@@ -1358,10 +1345,8 @@ async def test_document_event_emitter_off():
         doc_handle.on("change", on_change_2)
 
         # Make a change - both should be called
-        def set_value_1(doc):
+        with doc_handle.change() as doc:
             doc["key1"] = "value1"
-
-        await doc_handle.change(set_value_1)
         await asyncio.sleep(0.1)
 
         assert len(callback1_count) == 1
@@ -1371,10 +1356,8 @@ async def test_document_event_emitter_off():
         doc_handle.off("change", on_change_1)
 
         # Make another change - only second should be called
-        def set_value_2(doc):
+        with doc_handle.change() as doc:
             doc["key2"] = "value2"
-
-        await doc_handle.change(set_value_2)
         await asyncio.sleep(0.1)
 
         # First callback should still be 1, second should be 2
@@ -1385,10 +1368,8 @@ async def test_document_event_emitter_off():
         doc_handle.off("change", on_change_2)
 
         # Make another change - neither should be called
-        def set_value_3(doc):
+        with doc_handle.change() as doc:
             doc["key3"] = "value3"
-
-        await doc_handle.change(set_value_3)
         await asyncio.sleep(0.1)
 
         # Both should still be at their previous counts
@@ -1440,21 +1421,17 @@ async def test_document_event_emitter_no_change_no_emit():
         doc_handle.on("change", on_change)
 
         # Call change() but don't actually modify anything
-        def no_op(doc):
+        with doc_handle.change() as doc:
             # Just read, don't modify
             doc.get("nonexistent_key")
-
-        await doc_handle.change(no_op)
         await asyncio.sleep(0.1)
 
         # Callback should NOT have been invoked
         assert len(callback_count) == 0
 
         # Now make an actual change
-        def set_value(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
-
-        await doc_handle.change(set_value)
         await asyncio.sleep(0.1)
 
         # Now callback should have been invoked once
@@ -1506,10 +1483,8 @@ async def test_repo_find_document():
         handle_a = await repo.create()
 
         # Set some content
-        def init_doc(doc):
+        with handle_a.change() as doc:
             doc["test"] = "value"
-
-        await handle_a.change(init_doc)
 
         # Get the URL
         url = handle_a.url
@@ -1560,11 +1535,9 @@ async def test_document_sync_basic():
         handle_a = await repo_a.create()
 
         # Set some initial content
-        def init_doc(doc):
+        with handle_a.change() as doc:
             doc["title"] = "Hello from Repo A"
             doc["count"] = 42
-
-        await handle_a.change(init_doc)
 
         # Give time for the document to sync to Repo B
         await asyncio.sleep(0.5)
@@ -1623,10 +1596,8 @@ async def test_doc_direct_access_read_only():
         doc_handle = await repo.create()
 
         # Initialize with some content
-        def init_doc(doc):
+        with doc_handle.change() as doc:
             doc["key"] = "value"
-
-        await doc_handle.change(init_doc)
         await asyncio.sleep(0.1)
 
         # Get read-only document reference
@@ -1687,11 +1658,9 @@ async def test_doc_concurrent_references():
         # Create a document with some content
         doc_handle = await repo.create()
 
-        def init_doc(doc):
+        with doc_handle.change() as doc:
             doc["key1"] = "value1"
             doc["key2"] = "value2"
-
-        await doc_handle.change(init_doc)
         await asyncio.sleep(0.1)
 
         # Get multiple document references
@@ -1726,10 +1695,8 @@ async def test_doc_read_during_change():
         # Create a document with initial content
         doc_handle = await repo.create()
 
-        def init_doc(doc):
+        with doc_handle.change() as doc:
             doc["counter"] = 0
-
-        await doc_handle.change(init_doc)
         await asyncio.sleep(0.1)
 
         # Get initial document reference
@@ -1737,10 +1704,8 @@ async def test_doc_read_during_change():
         assert doc_before["counter"] == 0
 
         # Make a change
-        def increment(doc):
+        with doc_handle.change() as doc:
             doc["counter"] = 1
-
-        await doc_handle.change(increment)
         await asyncio.sleep(0.1)
 
         # Get new document reference after change
@@ -1765,11 +1730,9 @@ async def test_doc_reference_across_awaits():
         # Create a document
         doc_handle = await repo.create()
 
-        def init_doc(doc):
+        with doc_handle.change() as doc:
             doc["field1"] = "value1"
             doc["field2"] = "value2"
-
-        await doc_handle.change(init_doc)
         await asyncio.sleep(0.1)
 
         # Get document reference
@@ -1794,20 +1757,18 @@ async def test_doc_reference_across_awaits():
         assert val1_again == "value1"
 
         # Make a change via handle
-        def update(doc):
+        with doc_handle.change() as doc:
             doc["field3"] = "value3"
-
-        await doc_handle.change(update)
         await asyncio.sleep(0.1)
 
         # Original reference should see the new value (mutex provides consistent view)
-        val3 = doc.get("field3")
+        val3 = doc_handle.doc().get("field3")
         assert val3 == "value3"
 
 
 @pytest.mark.asyncio
-async def test_doc_reference_in_change_callback():
-    """Test that doc() references work inside change() callbacks without deadlock."""
+async def test_doc_inside_change_raises_error():
+    """Test that doc() raises error inside change() block."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -1817,31 +1778,22 @@ async def test_doc_reference_in_change_callback():
         handle = await repo.create()
 
         # Set up initial state
-        def init_counter(doc):
+        with handle.change() as doc:
             doc["counter"] = 0
-
-        await handle.change(init_counter)
         await asyncio.sleep(0.1)
 
-        # Get a doc reference
-        doc_ref = handle.doc()
+        # Attempting to use handle.doc() inside change block should raise
+        with pytest.raises(RuntimeError) as exc_info:
+            with handle.change() as doc:
+                # This should raise an error
+                _ = handle.doc()["counter"]
 
-        # Use the doc reference inside a change callback
-        # This should NOT deadlock
-        def increment_using_ref(doc):
-            doc["counter"] = doc_ref["counter"] + 1
-
-        await handle.change(increment_using_ref)
-        await asyncio.sleep(0.1)
-
-        # Verify the change worked
-        doc = handle.doc()
-        assert doc["counter"] == 1
+        assert "change()" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_nested_doc_reference_in_change():
-    """Test that nested doc() references work in change callbacks."""
+async def test_read_before_write_in_change():
+    """Test reading values before modifying them in a change block."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -1851,25 +1803,19 @@ async def test_nested_doc_reference_in_change():
         handle = await repo.create()
 
         # Set up initial values
-        def init_values(doc):
+        with handle.change() as doc:
             doc["value1"] = 10
             doc["value2"] = 20
-
-        await handle.change(init_values)
         await asyncio.sleep(0.1)
 
-        # Get a doc reference
+        # Read values before the change block
         doc_ref = handle.doc()
+        val1 = doc_ref["value1"]
+        val2 = doc_ref["value2"]
 
-        # Use doc reference to read multiple values in change callback
-        def compute_sum(doc):
-            # Read from external doc reference
-            val1 = doc_ref["value1"]
-            val2 = doc_ref["value2"]
-            # Write to current doc
+        # Use the read values in the change block
+        with handle.change() as doc:
             doc["sum"] = val1 + val2
-
-        await handle.change(compute_sum)
         await asyncio.sleep(0.1)
 
         # Verify
@@ -1878,8 +1824,8 @@ async def test_nested_doc_reference_in_change():
 
 
 @pytest.mark.asyncio
-async def test_different_doc_in_change_callback():
-    """Test that accessing different document's reference works in change callback."""
+async def test_different_doc_in_change_block():
+    """Test that accessing different document's reference works in change block."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -1890,27 +1836,20 @@ async def test_different_doc_in_change_callback():
         handle2 = await repo.create()
 
         # Set up both documents
-        def init_doc1(doc):
+        with handle1.change() as doc:
             doc["name"] = "doc1"
-
-        await handle1.change(init_doc1)
         await asyncio.sleep(0.1)
 
-        def init_doc2(doc):
+        with handle2.change() as doc:
             doc["name"] = "doc2"
-
-        await handle2.change(init_doc2)
         await asyncio.sleep(0.1)
 
-        # Get reference to doc2
-        doc2_ref = handle2.doc()
+        # Get reference to doc2 BEFORE entering handle1's change block
+        doc2_name = handle2.doc()["name"]
 
-        # Access doc2_ref inside doc1's change callback
-        # This should work because they're different actors
-        def use_doc2_ref(doc):
-            doc["other_name"] = doc2_ref["name"]
-
-        await handle1.change(use_doc2_ref)
+        # Use the value in handle1's change block
+        with handle1.change() as doc:
+            doc["other_name"] = doc2_name
         await asyncio.sleep(0.1)
 
         # Verify
@@ -1919,8 +1858,8 @@ async def test_different_doc_in_change_callback():
 
 
 @pytest.mark.asyncio
-async def test_multiple_doc_refs_in_change():
-    """Test that multiple doc() references work in change callback."""
+async def test_read_multiple_values_before_change():
+    """Test reading multiple values before a change block."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -1930,22 +1869,19 @@ async def test_multiple_doc_refs_in_change():
         handle = await repo.create()
 
         # Set up state
-        def init_values(doc):
+        with handle.change() as doc:
             doc["a"] = 1
             doc["b"] = 2
-
-        await handle.change(init_values)
         await asyncio.sleep(0.1)
 
-        # Get multiple references (simulating user having refs from different places)
-        ref1 = handle.doc()
-        ref2 = handle.doc()
+        # Read values before the change block
+        ref = handle.doc()
+        val_a = ref["a"]
+        val_b = ref["b"]
 
-        # Use both in change callback
-        def compute_sum(doc):
-            doc["sum"] = ref1["a"] + ref2["b"]
-
-        await handle.change(compute_sum)
+        # Use the values in change block
+        with handle.change() as doc:
+            doc["sum"] = val_a + val_b
         await asyncio.sleep(0.1)
 
         # Verify
@@ -1954,48 +1890,34 @@ async def test_multiple_doc_refs_in_change():
 
 
 @pytest.mark.asyncio
-async def test_nested_change_detection():
-    """Test that we can detect when we're in a change callback.
-
-    Note: Truly nested change() calls (calling change from within a change callback
-    on the same thread) will be detected and raise an error. This test verifies
-    the detection mechanism works.
-    """
+async def test_nested_change_raises_error():
+    """Test that nested change() calls raise an error."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
     repo = await Repo.load(storage)
 
     async with repo:
-        handle1 = await repo.create()
-        handle2 = await repo.create()
+        handle = await repo.create()
 
         # Set up initial state
-        def init_value(doc):
+        with handle.change() as doc:
             doc["value"] = 1
-
-        await handle1.change(init_value)
-        await handle2.change(init_value)
         await asyncio.sleep(0.1)
 
-        # Test that we can access handle1.doc() from within handle2's change callback
-        # These are different actors, so this should work fine
-        def use_other_doc(doc):
-            # Access doc from handle1 while in handle2's change callback
-            val = handle1.doc()["value"]
-            doc["copied_value"] = val
+        # Test that nested change() raises an error
+        with pytest.raises(RuntimeError) as exc_info:
+            with handle.change() as doc:
+                # Try to start another change - should fail
+                with handle.change() as inner_doc:
+                    inner_doc["nested"] = True
 
-        await handle2.change(use_other_doc)
-        await asyncio.sleep(0.1)
-
-        # Verify it worked
-        doc2 = handle2.doc()
-        assert doc2["copied_value"] == 1
+        assert "nest" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio
 async def test_context_cleanup_on_error():
-    """Test that context is cleaned up when callback raises error."""
+    """Test that context is cleaned up when change block raises error."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -2005,29 +1927,25 @@ async def test_context_cleanup_on_error():
         handle = await repo.create()
 
         # Set up state
-        def init_value(doc):
+        with handle.change() as doc:
             doc["value"] = 1
-
-        await handle.change(init_value)
         await asyncio.sleep(0.1)
 
-        # Callback that raises an error
+        # Change block that raises an error
         with pytest.raises(ValueError):
-
-            def error_callback(doc):
-                # Access doc() ref to set context, then raise error
-                _ = handle.doc()["value"]
+            with handle.change() as doc:
+                doc["value"] = 999  # This should be rolled back
                 raise ValueError("Intentional error")
 
-            await handle.change(error_callback)
-
         await asyncio.sleep(0.1)
 
-        # Context should be cleaned up - next change should work
-        def update_value(doc):
-            doc["value"] = 2
+        # Value should not have changed (rollback on error)
+        doc = handle.doc()
+        assert doc["value"] == 1
 
-        await handle.change(update_value)
+        # Context should be cleaned up - next change should work
+        with handle.change() as doc:
+            doc["value"] = 2
         await asyncio.sleep(0.1)
 
         # Verify subsequent operations work
@@ -2037,7 +1955,7 @@ async def test_context_cleanup_on_error():
 
 @pytest.mark.asyncio
 async def test_context_cleanup_after_success():
-    """Test that context is cleaned up after successful callback."""
+    """Test that context is cleaned up after successful change block."""
     from automerge.repo import InMemoryStorage
 
     storage = InMemoryStorage()
@@ -2047,18 +1965,14 @@ async def test_context_cleanup_after_success():
         handle = await repo.create()
 
         # First change
-        def first_change(doc):
+        with handle.change() as doc:
             doc["value"] = 1
-
-        await handle.change(first_change)
         await asyncio.sleep(0.1)
 
         # Context should be cleared after first change completes
         # Second change should not see it as "nested"
-        def second_change(doc):
+        with handle.change() as doc:
             doc["value"] = 2
-
-        await handle.change(second_change)
         await asyncio.sleep(0.1)
 
         # Verify

--- a/tests/test_s3_storage.py
+++ b/tests/test_s3_storage.py
@@ -1,0 +1,304 @@
+"""
+Integration tests for S3Storage against real AWS S3.
+
+Skipped unless S3_BUCKET_NAME, AWS_REGION, and S3_TEST_PREFIX are set.
+See README.md for configuration details.
+"""
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+# Skip all tests in this module if required env vars are not set
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("S3_BUCKET_NAME")
+        or not os.environ.get("AWS_REGION")
+        or not os.environ.get("S3_TEST_PREFIX"),
+        reason="S3_BUCKET_NAME, AWS_REGION, and S3_TEST_PREFIX environment variables required",
+    ),
+    pytest.mark.integration,
+]
+
+
+def get_test_prefix(test_name: str = "pytest") -> str:
+    """Get a unique S3 prefix for test isolation."""
+    base_prefix = os.environ["S3_TEST_PREFIX"].rstrip("/")
+    test_id = str(uuid.uuid4())[:8]
+    return f"{base_prefix}/{test_name}/{test_id}"
+
+
+@pytest.fixture
+def s3_storage():
+    """Create an S3Storage instance with a unique prefix for test isolation."""
+    from automerge.storages.s3 import S3Storage
+
+    bucket = os.environ["S3_BUCKET_NAME"]
+    region = os.environ["AWS_REGION"]
+    prefix = get_test_prefix()
+
+    return S3Storage(bucket=bucket, region=region, prefix=prefix)
+
+
+@pytest.fixture
+def storage_key():
+    """Import StorageKey for use in tests."""
+    from automerge._automerge import StorageKey
+
+    return StorageKey
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_put_and_load(s3_storage, storage_key):
+    """Test basic put and load operations with S3Storage."""
+    key = storage_key.from_parts(["test", "doc1", "data"])
+    value = b"hello world from automerge-py S3 test"
+
+    # Initially should be None
+    result = await s3_storage.load(key)
+    assert result is None
+
+    # Put value
+    await s3_storage.put(key, value)
+
+    # Should now load the value
+    result = await s3_storage.load(key)
+    assert result == value
+
+    # Cleanup
+    await s3_storage.delete(key)
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_load_missing_key(s3_storage, storage_key):
+    """Test that load returns None for missing keys."""
+    key = storage_key.from_parts(["nonexistent", "key", "path"])
+    result = await s3_storage.load(key)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_delete(s3_storage, storage_key):
+    """Test delete operation with S3Storage."""
+    key = storage_key.from_parts(["test", "delete", "me"])
+    value = b"to be deleted"
+
+    # Put and verify
+    await s3_storage.put(key, value)
+    assert await s3_storage.load(key) == value
+
+    # Delete
+    await s3_storage.delete(key)
+
+    # Should be None after delete
+    assert await s3_storage.load(key) is None
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_load_range(s3_storage, storage_key):
+    """Test load_range operation with S3Storage."""
+    # Put multiple values with same prefix
+    await s3_storage.put(storage_key.from_parts(["docs", "doc1", "data"]), b"data1")
+    await s3_storage.put(storage_key.from_parts(["docs", "doc2", "data"]), b"data2")
+    await s3_storage.put(storage_key.from_parts(["docs", "doc3", "data"]), b"data3")
+    await s3_storage.put(storage_key.from_parts(["other", "key"]), b"other")
+
+    # Load range with "docs" prefix
+    results = await s3_storage.load_range(storage_key.from_parts(["docs"]))
+
+    # Should get 3 results, not the "other" key
+    assert len(results) == 3
+
+    # Check that all results have correct prefix
+    for key, value in results:
+        parts = key.to_parts()
+        assert parts[0] == "docs"
+        assert value.startswith(b"data")
+
+    # Cleanup
+    await s3_storage.delete(storage_key.from_parts(["docs", "doc1", "data"]))
+    await s3_storage.delete(storage_key.from_parts(["docs", "doc2", "data"]))
+    await s3_storage.delete(storage_key.from_parts(["docs", "doc3", "data"]))
+    await s3_storage.delete(storage_key.from_parts(["other", "key"]))
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_load_range_empty(s3_storage, storage_key):
+    """Test load_range with no matching keys."""
+    results = await s3_storage.load_range(storage_key.from_parts(["nonexistent"]))
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_overwrite(s3_storage, storage_key):
+    """Test overwriting an existing key."""
+    key = storage_key.from_parts(["test", "overwrite", "key"])
+
+    # Put initial value
+    await s3_storage.put(key, b"initial")
+    assert await s3_storage.load(key) == b"initial"
+
+    # Overwrite with new value
+    await s3_storage.put(key, b"updated")
+    assert await s3_storage.load(key) == b"updated"
+
+    # Cleanup
+    await s3_storage.delete(key)
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_binary_data(s3_storage, storage_key):
+    """Test that S3Storage correctly handles binary data."""
+    key = storage_key.from_parts(["test", "binary", "doc"])
+    # All possible byte values
+    binary_data = bytes(range(256))
+
+    await s3_storage.put(key, binary_data)
+    result = await s3_storage.load(key)
+
+    assert result == binary_data
+
+    # Cleanup
+    await s3_storage.delete(key)
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_with_repo(s3_storage):
+    """Test S3Storage works with Repo."""
+    from automerge.repo import Repo
+
+    repo = await Repo.load(s3_storage)
+
+    async with repo:
+        # Create a document
+        handle = await repo.create()
+        await asyncio.sleep(0.1)  # Allow time for storage operations
+
+        # Make a change
+        with handle.change() as doc:
+            doc["key"] = "value"
+        await asyncio.sleep(0.1)
+
+        # Verify the change
+        assert handle.doc()["key"] == "value"
+
+
+@pytest.mark.asyncio
+async def test_s3_storage_with_credentials():
+    """Test S3Storage with explicit credentials."""
+    from automerge.storages.s3 import S3Storage
+
+    bucket = os.environ["S3_BUCKET_NAME"]
+    region = os.environ["AWS_REGION"]
+
+    # Get credentials from environment (simulating what the app would pass)
+    credentials = {
+        "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID"),
+        "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        "aws_session_token": os.environ.get("AWS_SESSION_TOKEN"),
+    }
+
+    # Skip if explicit credentials not available
+    if not credentials["aws_access_key_id"] or not credentials["aws_secret_access_key"]:
+        pytest.skip("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY not set")
+
+    storage = S3Storage(
+        bucket=bucket,
+        region=region,
+        prefix=get_test_prefix("credentials"),
+        credentials=credentials,
+    )
+
+    from automerge._automerge import StorageKey
+
+    key = StorageKey.from_parts(["cred", "test"])
+    await storage.put(key, b"credentials work")
+    result = await storage.load(key)
+    assert result == b"credentials work"
+
+    # Cleanup
+    await storage.delete(key)
+
+
+# Allow running as standalone script for manual testing
+if __name__ == "__main__":
+    import sys
+
+    async def main():
+        """Run tests manually."""
+        bucket = os.environ.get("S3_BUCKET_NAME")
+        region = os.environ.get("AWS_REGION")
+        base_prefix = os.environ.get("S3_TEST_PREFIX")
+
+        if not bucket or not region or not base_prefix:
+            print(
+                "❌ Error: S3_BUCKET_NAME, AWS_REGION, and S3_TEST_PREFIX environment variables required"
+            )
+            return 1
+
+        print("=" * 60)
+        print("S3Storage Manual Test Suite")
+        print("=" * 60)
+
+        from automerge._automerge import StorageKey
+        from automerge.storages.s3 import S3Storage
+
+        test_id = str(uuid.uuid4())[:8]
+        prefix = f"{base_prefix.rstrip('/')}/manual/{test_id}"
+
+        print(f"\nBucket: {bucket}")
+        print(f"Region: {region}")
+        print(f"Prefix: {prefix}")
+        print("-" * 60)
+
+        storage = S3Storage(bucket=bucket, region=region, prefix=prefix)
+
+        try:
+            # Test 1: put and load
+            print("\n1. Testing put() and load()...")
+            key = StorageKey.from_parts(["test", "doc1", "data"])
+            await storage.put(key, b"test data")
+            result = await storage.load(key)
+            assert result == b"test data"
+            print("   ✅ Passed")
+            await storage.delete(key)
+
+            # Test 2: load_range
+            print("\n2. Testing load_range()...")
+            await storage.put(StorageKey.from_parts(["range", "a"]), b"a")
+            await storage.put(StorageKey.from_parts(["range", "b"]), b"b")
+            results = await storage.load_range(StorageKey.from_parts(["range"]))
+            assert len(results) == 2
+            print("   ✅ Passed")
+            await storage.delete(StorageKey.from_parts(["range", "a"]))
+            await storage.delete(StorageKey.from_parts(["range", "b"]))
+
+            # Test 3: Repo integration
+            print("\n3. Testing Repo integration...")
+            from automerge.repo import Repo
+
+            repo = await Repo.load(storage)
+            async with repo:
+                handle = await repo.create()
+                await asyncio.sleep(0.1)
+                with handle.change() as doc:
+                    doc["test"] = 123
+                await asyncio.sleep(0.1)
+                assert handle.doc()["test"] == 123
+            print("   ✅ Passed")
+
+            print("\n" + "=" * 60)
+            print("🎉 All tests passed!")
+            print("=" * 60)
+            return 0
+
+        except Exception as e:
+            print(f"\n❌ Test failed: {e}")
+            import traceback
+
+            traceback.print_exc()
+            return 1
+
+    sys.exit(asyncio.run(main()))

--- a/tests/test_s3_storage_mock.py
+++ b/tests/test_s3_storage_mock.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for S3Storage using moto server mode.
+
+No AWS credentials required. See README.md for testing documentation.
+
+Uses moto's ThreadedMotoServer to run a local S3-compatible endpoint,
+which works correctly with aiobotocore's async HTTP client.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+import pytest_asyncio
+from moto.server import ThreadedMotoServer
+
+from automerge._automerge import StorageKey
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="session")
+def moto_server():
+    """Start moto server in a background thread for the entire test session."""
+    # Use port 0 to let the OS pick an available port
+    server = ThreadedMotoServer(ip_address="127.0.0.1", port=0)
+    server.start()
+    # Get the actual port that was assigned
+    host, port = server.get_host_and_port()
+    yield f"http://{host}:{port}"
+    server.stop()
+
+
+@pytest.fixture
+def endpoint_url(moto_server):
+    """Return the moto server endpoint URL."""
+    return moto_server
+
+
+@pytest.fixture
+def bucket_name():
+    """Return a unique bucket name for test isolation."""
+    return f"test-bucket-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def region():
+    return "us-east-1"
+
+
+@pytest_asyncio.fixture
+async def s3_storage(endpoint_url, bucket_name, region):
+    """Create an S3Storage instance connected to the moto server."""
+    from automerge.storages.s3 import S3Storage
+
+    # Create the bucket first using aiobotocore
+    from aiobotocore.session import AioSession
+
+    session = AioSession()
+    async with session.create_client(
+        "s3",
+        region_name=region,
+        endpoint_url=endpoint_url,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    ) as client:
+        await client.create_bucket(Bucket=bucket_name)
+
+    # Return storage instance pointing to moto server
+    return S3Storage(
+        bucket=bucket_name,
+        region=region,
+        endpoint_url=endpoint_url,
+        credentials={
+            "aws_access_key_id": "testing",
+            "aws_secret_access_key": "testing",
+        },
+    )
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_put_and_load(s3_storage):
+    """Test basic put and load operations."""
+    key = StorageKey.from_parts(["doc1", "data"])
+    value = b"hello world"
+
+    # Initially should be None
+    assert await s3_storage.load(key) is None
+
+    # Put and verify
+    await s3_storage.put(key, value)
+    assert await s3_storage.load(key) == value
+
+
+@pytest.mark.asyncio
+async def test_load_missing_key(s3_storage):
+    """Test that load returns None for missing keys."""
+    key = StorageKey.from_parts(["nonexistent", "key"])
+    assert await s3_storage.load(key) is None
+
+
+@pytest.mark.asyncio
+async def test_delete(s3_storage):
+    """Test delete operation."""
+    key = StorageKey.from_parts(["test", "delete"])
+    value = b"to be deleted"
+
+    await s3_storage.put(key, value)
+    assert await s3_storage.load(key) == value
+
+    await s3_storage.delete(key)
+    assert await s3_storage.load(key) is None
+
+
+@pytest.mark.asyncio
+async def test_load_range(s3_storage):
+    """Test load_range operation."""
+    # Put multiple values with same prefix
+    await s3_storage.put(StorageKey.from_parts(["docs", "doc1", "data"]), b"data1")
+    await s3_storage.put(StorageKey.from_parts(["docs", "doc2", "data"]), b"data2")
+    await s3_storage.put(StorageKey.from_parts(["docs", "doc3", "data"]), b"data3")
+    await s3_storage.put(StorageKey.from_parts(["other", "key"]), b"other")
+
+    # Load range with "docs" prefix
+    results = await s3_storage.load_range(StorageKey.from_parts(["docs"]))
+
+    assert len(results) == 3
+    for key, value in results:
+        parts = key.to_parts()
+        assert parts[0] == "docs"
+        assert value.startswith(b"data")
+
+
+@pytest.mark.asyncio
+async def test_load_range_empty(s3_storage):
+    """Test load_range with no matching keys."""
+    results = await s3_storage.load_range(StorageKey.from_parts(["nonexistent"]))
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_overwrite(s3_storage):
+    """Test overwriting an existing key."""
+    key = StorageKey.from_parts(["test", "overwrite"])
+
+    await s3_storage.put(key, b"initial")
+    assert await s3_storage.load(key) == b"initial"
+
+    await s3_storage.put(key, b"updated")
+    assert await s3_storage.load(key) == b"updated"
+
+
+@pytest.mark.asyncio
+async def test_binary_data(s3_storage):
+    """Test that S3Storage correctly handles binary data."""
+    key = StorageKey.from_parts(["test", "binary"])
+    binary_data = bytes(range(256))
+
+    await s3_storage.put(key, binary_data)
+    assert await s3_storage.load(key) == binary_data
+
+
+@pytest.mark.asyncio
+async def test_prefix_isolation(endpoint_url, region):
+    """Test that prefix isolation works correctly."""
+    from automerge.storages.s3 import S3Storage
+
+    # Create a unique bucket for this test
+    from aiobotocore.session import AioSession
+
+    test_bucket = f"prefix-test-{uuid.uuid4().hex[:8]}"
+    session = AioSession()
+    async with session.create_client(
+        "s3",
+        region_name=region,
+        endpoint_url=endpoint_url,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    ) as client:
+        await client.create_bucket(Bucket=test_bucket)
+
+    credentials = {
+        "aws_access_key_id": "testing",
+        "aws_secret_access_key": "testing",
+    }
+
+    storage_a = S3Storage(
+        bucket=test_bucket,
+        region=region,
+        prefix="user-a",
+        endpoint_url=endpoint_url,
+        credentials=credentials,
+    )
+    storage_b = S3Storage(
+        bucket=test_bucket,
+        region=region,
+        prefix="user-b",
+        endpoint_url=endpoint_url,
+        credentials=credentials,
+    )
+
+    key = StorageKey.from_parts(["doc", "data"])
+
+    await storage_a.put(key, b"value-a")
+    await storage_b.put(key, b"value-b")
+
+    assert await storage_a.load(key) == b"value-a"
+    assert await storage_b.load(key) == b"value-b"
+
+
+@pytest.mark.asyncio
+async def test_with_repo(s3_storage):
+    """Test S3Storage works with Repo."""
+    from automerge.repo import Repo
+
+    repo = await Repo.load(s3_storage)
+
+    async with repo:
+        handle = await repo.create()
+        await asyncio.sleep(0.05)
+
+        with handle.change() as doc:
+            doc["key"] = "value"
+        await asyncio.sleep(0.05)
+
+        assert handle.doc()["key"] == "value"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,361 @@
+"""Integration tests for WebSocket transport.
+
+These tests verify that document synchronization works correctly over WebSocket
+connections between repos.
+"""
+
+import asyncio
+
+# Skip all tests in this file if websockets is not installed
+import importlib
+
+import pytest
+
+if importlib.util.find_spec("websockets") is None:
+    pytest.skip("websockets not installed", allow_module_level=True)
+
+from automerge.repo import InMemoryStorage, Repo
+from automerge.transports import (
+    WebSocketClientTransport,
+    WebSocketServer,
+)
+
+
+@pytest.mark.asyncio
+async def test_websocket_document_sync():
+    """Test basic document synchronization over WebSocket."""
+    # Create two repos with separate storage
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        # Start WebSocket server with repo_b
+        async with WebSocketServer(repo_b, "localhost", 8768):
+            # Give server time to start
+            await asyncio.sleep(0.1)
+
+            # Connect repo_a as client
+            transport = await WebSocketClientTransport.connect("ws://localhost:8768")
+            _conn_task = asyncio.create_task(repo_a.connect(transport))
+
+            # Give time for handshake to complete
+            await asyncio.sleep(0.5)
+
+            # Create a document in repo_a (client)
+            handle_a = await repo_a.create()
+
+            # Set some content
+            def init_doc(doc):
+                doc["title"] = "WebSocket Test"
+                doc["count"] = 42
+
+            await handle_a.change(init_doc)
+
+            # Give time for sync
+            await asyncio.sleep(0.5)
+
+            # Verify the document synced to repo_b (server)
+            url = handle_a.url
+            handle_b = await repo_b.find(url)
+
+            assert handle_b is not None, "Document should have synced to server"
+            assert handle_b.document_id == handle_a.document_id
+
+            # Verify content matches
+            doc_a = handle_a.doc()
+            doc_b = handle_b.doc()
+
+            title_a = doc_a["title"]
+            title_b = doc_b["title"]
+            assert title_a == title_b == "WebSocket Test"
+
+            count_a = doc_a["count"]
+            count_b = doc_b["count"]
+            assert count_a == count_b == 42
+
+            # Close connection
+            await transport.close()
+            await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_bidirectional_sync():
+    """Test document synchronization in both directions over WebSocket."""
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        # Start WebSocket server with repo_b
+        async with WebSocketServer(repo_b, "localhost", 8769):
+            await asyncio.sleep(0.1)
+
+            # Connect repo_a as client
+            transport = await WebSocketClientTransport.connect("ws://localhost:8769")
+            _conn_task = asyncio.create_task(repo_a.connect(transport))
+            await asyncio.sleep(0.5)
+
+            # Create document in client (repo_a)
+            handle_a1 = await repo_a.create()
+
+            def init_doc_a(doc):
+                doc["source"] = "client"
+
+            await handle_a1.change(init_doc_a)
+            await asyncio.sleep(0.5)
+
+            # Create document in server (repo_b)
+            handle_b1 = await repo_b.create()
+
+            def init_doc_b(doc):
+                doc["source"] = "server"
+
+            await handle_b1.change(init_doc_b)
+            await asyncio.sleep(0.5)
+
+            # Verify client doc synced to server
+            handle_a1_on_b = await repo_b.find(handle_a1.url)
+            assert handle_a1_on_b is not None, "Client doc should sync to server"
+
+            # Verify
+            doc_a1_on_b = handle_a1_on_b.doc()
+            source = doc_a1_on_b["source"]
+            assert source == "client"
+
+            # Verify server doc synced to client
+            handle_b1_on_a = await repo_a.find(handle_b1.url)
+            assert handle_b1_on_a is not None, "Server doc should sync to client"
+
+            doc_b1_on_a = handle_b1_on_a.doc()
+            source = doc_b1_on_a["source"]
+            assert source == "server"
+
+            await transport.close()
+            await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_multiple_clients():
+    """Test multiple clients connecting to one server."""
+    storage_server = InMemoryStorage()
+    storage_client1 = InMemoryStorage()
+    storage_client2 = InMemoryStorage()
+
+    repo_server = await Repo.load(storage_server)
+    repo_client1 = await Repo.load(storage_client1)
+    repo_client2 = await Repo.load(storage_client2)
+
+    async with repo_server, repo_client1, repo_client2:
+        # Start WebSocket server
+        async with WebSocketServer(repo_server, "localhost", 8770):
+            await asyncio.sleep(0.1)
+
+            # Connect two clients
+            transport1 = await WebSocketClientTransport.connect("ws://localhost:8770")
+            transport2 = await WebSocketClientTransport.connect("ws://localhost:8770")
+
+            _conn_task1 = asyncio.create_task(repo_client1.connect(transport1))
+            _conn_task2 = asyncio.create_task(repo_client2.connect(transport2))
+            await asyncio.sleep(0.5)
+
+            # Create document in client1
+            handle1 = await repo_client1.create()
+
+            def init_doc(doc):
+                doc["from"] = "client1"
+
+            await handle1.change(init_doc)
+            await asyncio.sleep(0.5)
+
+            # Verify it synced to server
+            handle_on_server = await repo_server.find(handle1.url)
+            assert handle_on_server is not None, "Doc should sync to server"
+
+            # Verify it synced to client2
+            handle_on_client2 = await repo_client2.find(handle1.url)
+            assert handle_on_client2 is not None, "Doc should sync to client2"
+
+            # Verify
+            doc_on_client2 = handle_on_client2.doc()
+            from_field = doc_on_client2["from"]
+            assert from_field == "client1"
+
+            await transport1.close()
+            await transport2.close()
+            await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_document_changes_sync():
+    """Test that document changes propagate over WebSocket."""
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        async with WebSocketServer(repo_b, "localhost", 8771):
+            await asyncio.sleep(0.1)
+
+            transport = await WebSocketClientTransport.connect("ws://localhost:8771")
+            _conn_task = asyncio.create_task(repo_a.connect(transport))
+            await asyncio.sleep(0.5)
+
+            # Create document with initial content
+            handle_a = await repo_a.create()
+
+            def init_doc(doc):
+                doc["counter"] = 0
+
+            await handle_a.change(init_doc)
+            await asyncio.sleep(0.5)
+
+            # Get handle on repo_b
+            handle_b = await repo_b.find(handle_a.url)
+            assert handle_b is not None
+
+            # Make multiple changes on repo_a
+            for i in range(1, 4):
+
+                def increment(doc):
+                    current = doc["counter"]
+                    doc["counter"] = current + 1
+
+                await handle_a.change(increment)
+                await asyncio.sleep(0.3)
+
+            # Verify final value on repo_b
+            doc_b = handle_b.doc()
+            counter_b = doc_b["counter"]
+            assert counter_b == 3, "Counter should be 3 after three increments"
+
+            await transport.close()
+            await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_connection_failure():
+    """Test handling of connection failure."""
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        # Try to connect to non-existent server
+        try:
+            _transport = await asyncio.wait_for(
+                WebSocketClientTransport.connect("ws://localhost:9999"),
+                timeout=2.0,
+            )
+            assert False, "Should have failed to connect"
+        except (ConnectionRefusedError, OSError, asyncio.TimeoutError):
+            # Expected - connection should fail
+            pass
+
+
+@pytest.mark.asyncio
+async def test_websocket_connection_lost_during_operation():
+    """Test handling of connection lost during operation."""
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        # Start server
+        server = WebSocketServer(repo_b, "localhost", 8772)
+        await server.start()
+        await asyncio.sleep(0.1)
+
+        try:
+            # Connect client
+            transport = await WebSocketClientTransport.connect("ws://localhost:8772")
+            _conn_task = asyncio.create_task(repo_a.connect(transport))
+            await asyncio.sleep(0.5)
+
+            # Create document
+            handle = await repo_a.create()
+
+            def init_doc(doc):
+                doc["test"] = "value"
+
+            await handle.change(init_doc)
+            await asyncio.sleep(0.3)
+
+            # Force close the server (simulates connection loss)
+            await server.stop()
+            await asyncio.sleep(0.3)
+
+            # Connection task should complete (with error reason)
+            # The repo should handle this gracefully
+            # Note: conn_task may already be done at this point
+
+        finally:
+            # Clean up
+            if server._server is not None:
+                await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_server_shutdown_with_clients():
+    """Test graceful server shutdown while clients are connected."""
+    storage_server = InMemoryStorage()
+    storage_client = InMemoryStorage()
+
+    repo_server = await Repo.load(storage_server)
+    repo_client = await Repo.load(storage_client)
+
+    async with repo_server, repo_client:
+        # Start server
+        server = WebSocketServer(repo_server, "localhost", 8773)
+        await server.start()
+        await asyncio.sleep(0.1)
+
+        # Connect client
+        transport = await WebSocketClientTransport.connect("ws://localhost:8773")
+        _conn_task = asyncio.create_task(repo_client.connect(transport))
+        await asyncio.sleep(0.3)
+
+        # Verify connection is established
+        connections = repo_server._hub.connections()
+        assert len(connections) > 0, "Should have active connection"
+
+        # Stop server gracefully
+        await server.stop()
+        await asyncio.sleep(0.3)
+
+        # Server should have cleaned up
+        assert server._server is None
+        assert len(server._connections) == 0
+
+
+@pytest.mark.asyncio
+async def test_websocket_binary_message_validation():
+    """Test that non-binary messages are rejected."""
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        async with WebSocketServer(repo_b, "localhost", 8774):
+            await asyncio.sleep(0.1)
+
+            transport = await WebSocketClientTransport.connect("ws://localhost:8774")
+
+            # Test sending non-bytes raises TypeError
+            try:
+                await transport.send("not bytes")  # type: ignore
+                assert False, "Should have raised TypeError"
+            except TypeError as e:
+                assert "must be bytes" in str(e)
+
+            await transport.close()
+            await asyncio.sleep(0.1)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -48,11 +48,9 @@ async def test_websocket_document_sync():
             handle_a = await repo_a.create()
 
             # Set some content
-            def init_doc(doc):
+            with handle_a.change() as doc:
                 doc["title"] = "WebSocket Test"
                 doc["count"] = 42
-
-            await handle_a.change(init_doc)
 
             # Give time for sync
             await asyncio.sleep(0.5)
@@ -103,19 +101,15 @@ async def test_websocket_bidirectional_sync():
             # Create document in client (repo_a)
             handle_a1 = await repo_a.create()
 
-            def init_doc_a(doc):
+            with handle_a1.change() as doc:
                 doc["source"] = "client"
-
-            await handle_a1.change(init_doc_a)
             await asyncio.sleep(0.5)
 
             # Create document in server (repo_b)
             handle_b1 = await repo_b.create()
 
-            def init_doc_b(doc):
+            with handle_b1.change() as doc:
                 doc["source"] = "server"
-
-            await handle_b1.change(init_doc_b)
             await asyncio.sleep(0.5)
 
             # Verify client doc synced to server
@@ -166,10 +160,8 @@ async def test_websocket_multiple_clients():
             # Create document in client1
             handle1 = await repo_client1.create()
 
-            def init_doc(doc):
+            with handle1.change() as doc:
                 doc["from"] = "client1"
-
-            await handle1.change(init_doc)
             await asyncio.sleep(0.5)
 
             # Verify it synced to server
@@ -210,10 +202,8 @@ async def test_websocket_document_changes_sync():
             # Create document with initial content
             handle_a = await repo_a.create()
 
-            def init_doc(doc):
+            with handle_a.change() as doc:
                 doc["counter"] = 0
-
-            await handle_a.change(init_doc)
             await asyncio.sleep(0.5)
 
             # Get handle on repo_b
@@ -222,12 +212,9 @@ async def test_websocket_document_changes_sync():
 
             # Make multiple changes on repo_a
             for i in range(1, 4):
-
-                def increment(doc):
-                    current = doc["counter"]
+                current = handle_a.doc()["counter"]
+                with handle_a.change() as doc:
                     doc["counter"] = current + 1
-
-                await handle_a.change(increment)
                 await asyncio.sleep(0.3)
 
             # Verify final value on repo_b
@@ -282,10 +269,8 @@ async def test_websocket_connection_lost_during_operation():
             # Create document
             handle = await repo_a.create()
 
-            def init_doc(doc):
+            with handle.change() as doc:
                 doc["test"] = "value"
-
-            await handle.change(init_doc)
             await asyncio.sleep(0.3)
 
             # Force close the server (simulates connection loss)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"
+
+[[package]]
+name = "automerge"
+source = { editable = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "automerge"
-version = "0.2.0.dev1"
+version = "0.2.0.dev2"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,583 @@
 version = 1
 revision = 3
 requires-python = ">=3.8"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
 
 [[package]]
 name = "automerge"
 version = "0.2.0.dev1"
 source = { editable = "." }
+
+[package.optional-dependencies]
+all = [
+    { name = "websockets", version = "13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+websocket = [
+    { name = "websockets", version = "13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "websockets", marker = "extra == 'all'", specifier = ">=12.0" },
+    { name = "websockets", marker = "extra == 'websocket'", specifier = ">=12.0" },
+]
+provides-extras = ["websocket", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "packaging", marker = "python_full_version == '3.9.*'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pygments", marker = "python_full_version == '3.9.*'" },
+    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855, upload-time = "2024-08-22T08:03:18.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024, upload-time = "2024-08-22T08:03:15.536Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "13.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/73/9223dbc7be3dcaf2a7bbf756c351ec8da04b1fa573edaf545b95f6b0c7fd/websockets-13.1.tar.gz", hash = "sha256:a3b3366087c1bc0a2795111edcadddb8b3b59509d5db5d7ea3fdd69f954a8878", size = 158549, upload-time = "2024-09-21T17:34:21.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/94/d15dbfc6a5eb636dbc754303fba18208f2e88cf97e733e1d64fb9cb5c89e/websockets-13.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f48c749857f8fb598fb890a75f540e3221d0976ed0bf879cf3c7eef34151acee", size = 157815, upload-time = "2024-09-21T17:32:27.107Z" },
+    { url = "https://files.pythonhosted.org/packages/30/02/c04af33f4663945a26f5e8cf561eb140c35452b50af47a83c3fbcfe62ae1/websockets-13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7e72ce6bda6fb9409cc1e8164dd41d7c91466fb599eb047cfda72fe758a34a7", size = 155466, upload-time = "2024-09-21T17:32:28.428Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e8/719f08d12303ea643655e52d9e9851b2dadbb1991d4926d9ce8862efa2f5/websockets-13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f779498eeec470295a2b1a5d97aa1bc9814ecd25e1eb637bd9d1c73a327387f6", size = 155716, upload-time = "2024-09-21T17:32:29.905Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e1/14963ae0252a8925f7434065d25dcd4701d5e281a0b4b460a3b5963d2594/websockets-13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4676df3fe46956fbb0437d8800cd5f2b6d41143b6e7e842e60554398432cf29b", size = 164806, upload-time = "2024-09-21T17:32:31.384Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/fa/ab28441bae5e682a0f7ddf3d03440c0c352f930da419301f4a717f675ef3/websockets-13.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7affedeb43a70351bb811dadf49493c9cfd1ed94c9c70095fd177e9cc1541fa", size = 163810, upload-time = "2024-09-21T17:32:32.384Z" },
+    { url = "https://files.pythonhosted.org/packages/44/77/dea187bd9d16d4b91566a2832be31f99a40d0f5bfa55eeb638eb2c3bc33d/websockets-13.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1971e62d2caa443e57588e1d82d15f663b29ff9dfe7446d9964a4b6f12c1e700", size = 164125, upload-time = "2024-09-21T17:32:33.398Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d9/3af14544e83f1437eb684b399e6ba0fa769438e869bf5d83d74bc197fae8/websockets-13.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5f2e75431f8dc4a47f31565a6e1355fb4f2ecaa99d6b89737527ea917066e26c", size = 164532, upload-time = "2024-09-21T17:32:35.109Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8a/6d332eabe7d59dfefe4b8ba6f46c8c5fabb15b71c8a8bc3d2b65de19a7b6/websockets-13.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:58cf7e75dbf7e566088b07e36ea2e3e2bd5676e22216e4cad108d4df4a7402a0", size = 163948, upload-time = "2024-09-21T17:32:36.214Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/91/a0aeadbaf3017467a1ee03f8fb67accdae233fe2d5ad4b038c0a84e357b0/websockets-13.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c90d6dec6be2c7d03378a574de87af9b1efea77d0c52a8301dd831ece938452f", size = 163898, upload-time = "2024-09-21T17:32:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/71/31/a90fb47c63e0ae605be914b0b969d7c6e6ffe2038cd744798e4b3fbce53b/websockets-13.1-cp310-cp310-win32.whl", hash = "sha256:730f42125ccb14602f455155084f978bd9e8e57e89b569b4d7f0f0c17a448ffe", size = 158706, upload-time = "2024-09-21T17:32:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ca/9540a9ba80da04dc7f36d790c30cae4252589dbd52ccdc92e75b0be22437/websockets-13.1-cp310-cp310-win_amd64.whl", hash = "sha256:5993260f483d05a9737073be197371940c01b257cc45ae3f1d5d7adb371b266a", size = 159141, upload-time = "2024-09-21T17:32:40.495Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f0/cf0b8a30d86b49e267ac84addbebbc7a48a6e7bb7c19db80f62411452311/websockets-13.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:61fc0dfcda609cda0fc9fe7977694c0c59cf9d749fbb17f4e9483929e3c48a19", size = 157813, upload-time = "2024-09-21T17:32:42.188Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e7/22285852502e33071a8cf0ac814f8988480ec6db4754e067b8b9d0e92498/websockets-13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ceec59f59d092c5007e815def4ebb80c2de330e9588e101cf8bd94c143ec78a5", size = 155469, upload-time = "2024-09-21T17:32:43.858Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/c8c7c1e5b40ee03c5cc235955b0fb1ec90e7e37685a5f69229ad4708dcde/websockets-13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1dca61c6db1166c48b95198c0b7d9c990b30c756fc2923cc66f68d17dc558fd", size = 155717, upload-time = "2024-09-21T17:32:44.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/c50999b9b848b1332b07c7fd8886179ac395cb766fda62725d1539e7bc6c/websockets-13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:308e20f22c2c77f3f39caca508e765f8725020b84aa963474e18c59accbf4c02", size = 165379, upload-time = "2024-09-21T17:32:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/49/4a4ad8c072f18fd79ab127650e47b160571aacfc30b110ee305ba25fffc9/websockets-13.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d516c325e6540e8a57b94abefc3459d7dab8ce52ac75c96cad5549e187e3a7", size = 164376, upload-time = "2024-09-21T17:32:46.987Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9b/8c06d425a1d5a74fd764dd793edd02be18cf6fc3b1ccd1f29244ba132dc0/websockets-13.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87c6e35319b46b99e168eb98472d6c7d8634ee37750d7693656dc766395df096", size = 164753, upload-time = "2024-09-21T17:32:48.046Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5b/0acb5815095ff800b579ffc38b13ab1b915b317915023748812d24e0c1ac/websockets-13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5f9fee94ebafbc3117c30be1844ed01a3b177bb6e39088bc6b2fa1dc15572084", size = 165051, upload-time = "2024-09-21T17:32:49.271Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/c3891c20114eacb1af09dedfcc620c65c397f4fd80a7009cd12d9457f7f5/websockets-13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7c1e90228c2f5cdde263253fa5db63e6653f1c00e7ec64108065a0b9713fa1b3", size = 164489, upload-time = "2024-09-21T17:32:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/28/09/af9e19885539759efa2e2cd29b8b3f9eecef7ecefea40d46612f12138b36/websockets-13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6548f29b0e401eea2b967b2fdc1c7c7b5ebb3eeb470ed23a54cd45ef078a0db9", size = 164438, upload-time = "2024-09-21T17:32:52.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/08/6f38b8e625b3d93de731f1d248cc1493327f16cb45b9645b3e791782cff0/websockets-13.1-cp311-cp311-win32.whl", hash = "sha256:c11d4d16e133f6df8916cc5b7e3e96ee4c44c936717d684a94f48f82edb7c92f", size = 158710, upload-time = "2024-09-21T17:32:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/ec8832ecb9bb04a8d318149005ed8cee0ba4e0205835da99e0aa497a091f/websockets-13.1-cp311-cp311-win_amd64.whl", hash = "sha256:d04f13a1d75cb2b8382bdc16ae6fa58c97337253826dfe136195b7f89f661557", size = 159137, upload-time = "2024-09-21T17:32:54.721Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/c426282f543b3c0296cf964aa5a7bb17e984f58dde23460c3d39b3148fcf/websockets-13.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:9d75baf00138f80b48f1eac72ad1535aac0b6461265a0bcad391fc5aba875cfc", size = 157821, upload-time = "2024-09-21T17:32:56.442Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/85/22529867010baac258da7c45848f9415e6cf37fef00a43856627806ffd04/websockets-13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9b6f347deb3dcfbfde1c20baa21c2ac0751afaa73e64e5b693bb2b848efeaa49", size = 155480, upload-time = "2024-09-21T17:32:57.698Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2c/bdb339bfbde0119a6e84af43ebf6275278698a2241c2719afc0d8b0bdbf2/websockets-13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de58647e3f9c42f13f90ac7e5f58900c80a39019848c5547bc691693098ae1bd", size = 155715, upload-time = "2024-09-21T17:32:59.429Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/8612029ea04c5c22bf7af2fd3d63876c4eaeef9b97e86c11972a43aa0e6c/websockets-13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1b54689e38d1279a51d11e3467dd2f3a50f5f2e879012ce8f2d6943f00e83f0", size = 165647, upload-time = "2024-09-21T17:33:00.495Z" },
+    { url = "https://files.pythonhosted.org/packages/56/04/1681ed516fa19ca9083f26d3f3a302257e0911ba75009533ed60fbb7b8d1/websockets-13.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf1781ef73c073e6b0f90af841aaf98501f975d306bbf6221683dd594ccc52b6", size = 164592, upload-time = "2024-09-21T17:33:02.223Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6f/a96417a49c0ed132bb6087e8e39a37db851c70974f5c724a4b2a70066996/websockets-13.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d23b88b9388ed85c6faf0e74d8dec4f4d3baf3ecf20a65a47b836d56260d4b9", size = 165012, upload-time = "2024-09-21T17:33:03.288Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8b/fccf294919a1b37d190e86042e1a907b8f66cff2b61e9befdbce03783e25/websockets-13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3c78383585f47ccb0fcf186dcb8a43f5438bd7d8f47d69e0b56f71bf431a0a68", size = 165311, upload-time = "2024-09-21T17:33:04.728Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/61/f8615cf7ce5fe538476ab6b4defff52beb7262ff8a73d5ef386322d9761d/websockets-13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d6d300f8ec35c24025ceb9b9019ae9040c1ab2f01cddc2bcc0b518af31c75c14", size = 164692, upload-time = "2024-09-21T17:33:05.829Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f1/a29dd6046d3a722d26f182b783a7997d25298873a14028c4760347974ea3/websockets-13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a9dcaf8b0cc72a392760bb8755922c03e17a5a54e08cca58e8b74f6902b433cf", size = 164686, upload-time = "2024-09-21T17:33:06.823Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/99/ab1cdb282f7e595391226f03f9b498f52109d25a2ba03832e21614967dfa/websockets-13.1-cp312-cp312-win32.whl", hash = "sha256:2f85cf4f2a1ba8f602298a853cec8526c2ca42a9a4b947ec236eaedb8f2dc80c", size = 158712, upload-time = "2024-09-21T17:33:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/46/93/e19160db48b5581feac8468330aa11b7292880a94a37d7030478596cc14e/websockets-13.1-cp312-cp312-win_amd64.whl", hash = "sha256:38377f8b0cdeee97c552d20cf1865695fcd56aba155ad1b4ca8779a5b6ef4ac3", size = 159145, upload-time = "2024-09-21T17:33:09.202Z" },
+    { url = "https://files.pythonhosted.org/packages/51/20/2b99ca918e1cbd33c53db2cace5f0c0cd8296fc77558e1908799c712e1cd/websockets-13.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9ab1e71d3d2e54a0aa646ab6d4eebfaa5f416fe78dfe4da2839525dc5d765c6", size = 157828, upload-time = "2024-09-21T17:33:10.987Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/47/0932a71d3d9c0e9483174f60713c84cee58d62839a143f21a2bcdbd2d205/websockets-13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b9d7439d7fab4dce00570bb906875734df13d9faa4b48e261c440a5fec6d9708", size = 155487, upload-time = "2024-09-21T17:33:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/60/f1711eb59ac7a6c5e98e5637fef5302f45b6f76a2c9d64fd83bbb341377a/websockets-13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:327b74e915cf13c5931334c61e1a41040e365d380f812513a255aa804b183418", size = 155721, upload-time = "2024-09-21T17:33:13.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e6/ba9a8db7f9d9b0e5f829cf626ff32677f39824968317223605a6b419d445/websockets-13.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:325b1ccdbf5e5725fdcb1b0e9ad4d2545056479d0eee392c291c1bf76206435a", size = 165609, upload-time = "2024-09-21T17:33:14.967Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/22/4ec80f1b9c27a0aebd84ccd857252eda8418ab9681eb571b37ca4c5e1305/websockets-13.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:346bee67a65f189e0e33f520f253d5147ab76ae42493804319b5716e46dddf0f", size = 164556, upload-time = "2024-09-21T17:33:17.113Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ac/35f423cb6bb15600438db80755609d27eda36d4c0b3c9d745ea12766c45e/websockets-13.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91a0fa841646320ec0d3accdff5b757b06e2e5c86ba32af2e0815c96c7a603c5", size = 164993, upload-time = "2024-09-21T17:33:18.168Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4e/98db4fd267f8be9e52e86b6ee4e9aa7c42b83452ea0ea0672f176224b977/websockets-13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18503d2c5f3943e93819238bf20df71982d193f73dcecd26c94514f417f6b135", size = 165360, upload-time = "2024-09-21T17:33:19.233Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/15/3f0de7cda70ffc94b7e7024544072bc5b26e2c1eb36545291abb755d8cdb/websockets-13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9cd1af7e18e5221d2878378fbc287a14cd527fdd5939ed56a18df8a31136bb2", size = 164745, upload-time = "2024-09-21T17:33:20.361Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/66b6b756aebbd680b934c8bdbb6dcb9ce45aad72cde5f8a7208dbb00dd36/websockets-13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:70c5be9f416aa72aab7a2a76c90ae0a4fe2755c1816c153c1a2bcc3333ce4ce6", size = 164732, upload-time = "2024-09-21T17:33:23.103Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c6/12e3aab52c11aeb289e3dbbc05929e7a9d90d7a9173958477d3ef4f8ce2d/websockets-13.1-cp313-cp313-win32.whl", hash = "sha256:624459daabeb310d3815b276c1adef475b3e6804abaf2d9d2c061c319f7f187d", size = 158709, upload-time = "2024-09-21T17:33:24.196Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d8/63d6194aae711d7263df4498200c690a9c39fb437ede10f3e157a6343e0d/websockets-13.1-cp313-cp313-win_amd64.whl", hash = "sha256:c518e84bb59c2baae725accd355c8dc517b4a3ed8db88b4bc93c78dae2974bf2", size = 159144, upload-time = "2024-09-21T17:33:25.96Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/59872420e5bce60db166d6fba39ee24c719d339fb0ae48cb2ce580129882/websockets-13.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c7934fd0e920e70468e676fe7f1b7261c1efa0d6c037c6722278ca0228ad9d0d", size = 157811, upload-time = "2024-09-21T17:33:27.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f7/0610032e0d3981758fdd6ee7c68cc02ebf668a762c5178d3d91748228849/websockets-13.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:149e622dc48c10ccc3d2760e5f36753db9cacf3ad7bc7bbbfd7d9c819e286f23", size = 155471, upload-time = "2024-09-21T17:33:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/c43173a72ea395263a427a36d25bce2675f41c809424466a13c61a9a2d61/websockets-13.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a569eb1b05d72f9bce2ebd28a1ce2054311b66677fcd46cf36204ad23acead8c", size = 155713, upload-time = "2024-09-21T17:33:29.795Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/8fa930c6426a56c47910792717787640329e4a0e37cdfda20cf89da67126/websockets-13.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95df24ca1e1bd93bbca51d94dd049a984609687cb2fb08a7f2c56ac84e9816ea", size = 164995, upload-time = "2024-09-21T17:33:30.802Z" },
+    { url = "https://files.pythonhosted.org/packages/27/29/50ed4c68a3f606565a2db4b13948ae7b6f6c53aa9f8f258d92be6698d276/websockets-13.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8dbb1bf0c0a4ae8b40bdc9be7f644e2f3fb4e8a9aca7145bfa510d4a374eeb7", size = 164057, upload-time = "2024-09-21T17:33:31.862Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0e/60da63b1c53c47f389f79312b3356cb305600ffad1274d7ec473128d4e6b/websockets-13.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:035233b7531fb92a76beefcbf479504db8c72eb3bff41da55aecce3a0f729e54", size = 164340, upload-time = "2024-09-21T17:33:33.022Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ef/d87c5fc0aa7fafad1d584b6459ddfe062edf0d0dd64800a02e67e5de048b/websockets-13.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:e4450fc83a3df53dec45922b576e91e94f5578d06436871dce3a6be38e40f5db", size = 164222, upload-time = "2024-09-21T17:33:34.423Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c4/7916e1f6b5252d3dcb9121b67d7fdbb2d9bf5067a6d8c88885ba27a9e69c/websockets-13.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:463e1c6ec853202dd3657f156123d6b4dad0c546ea2e2e38be2b3f7c5b8e7295", size = 163647, upload-time = "2024-09-21T17:33:35.841Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/2ebebb807f10993c35c10cbd3628a7944b66bd5fb6632a561f8666f3a68e/websockets-13.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6d6855bbe70119872c05107e38fbc7f96b1d8cb047d95c2c50869a46c65a8e96", size = 163590, upload-time = "2024-09-21T17:33:37.61Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/82/d48911f56bb993c11099a1ff1d4041d9d1481d50271100e8ee62bc28f365/websockets-13.1-cp38-cp38-win32.whl", hash = "sha256:204e5107f43095012b00f1451374693267adbb832d29966a01ecc4ce1db26faf", size = 158701, upload-time = "2024-09-21T17:33:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/b3/945aacb21fc89ad150403cbaa974c9e846f098f16d9f39a3dd6094f9beb1/websockets-13.1-cp38-cp38-win_amd64.whl", hash = "sha256:485307243237328c022bc908b90e4457d0daa8b5cf4b3723fd3c4a8012fce4c6", size = 159146, upload-time = "2024-09-21T17:33:39.855Z" },
+    { url = "https://files.pythonhosted.org/packages/61/26/5f7a7fb03efedb4f90ed61968338bfe7c389863b0ceda239b94ae61c5ae4/websockets-13.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9b37c184f8b976f0c0a231a5f3d6efe10807d41ccbe4488df8c74174805eea7d", size = 157810, upload-time = "2024-09-21T17:33:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d4/9b4814a07dffaa7a79d71b4944d10836f9adbd527a113f6675734ef3abed/websockets-13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:163e7277e1a0bd9fb3c8842a71661ad19c6aa7bb3d6678dc7f89b17fbcc4aeb7", size = 155467, upload-time = "2024-09-21T17:33:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1a/2abdc7ce3b56429ae39d6bfb48d8c791f5a26bbcb6f44aabcf71ffc3fda2/websockets-13.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b889dbd1342820cc210ba44307cf75ae5f2f96226c0038094455a96e64fb07a", size = 155714, upload-time = "2024-09-21T17:33:43.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/98/189d7cf232753a719b2726ec55e7922522632248d5d830adf078e3f612be/websockets-13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:586a356928692c1fed0eca68b4d1c2cbbd1ca2acf2ac7e7ebd3b9052582deefa", size = 164587, upload-time = "2024-09-21T17:33:44.27Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2b/fb77cedf3f9f55ef8605238c801eef6b9a5269b01a396875a86896aea3a6/websockets-13.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7bd6abf1e070a6b72bfeb71049d6ad286852e285f146682bf30d0296f5fbadfa", size = 163588, upload-time = "2024-09-21T17:33:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b7/070481b83d2d5ac0f19233d9f364294e224e6478b0762f07fa7f060e0619/websockets-13.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2aad13a200e5934f5a6767492fb07151e1de1d6079c003ab31e1823733ae79", size = 163894, upload-time = "2024-09-21T17:33:46.651Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/be/d6e1cff7d441cfe5eafaacc5935463e5f14c8b1c0d39cb8afde82709b55a/websockets-13.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:df01aea34b6e9e33572c35cd16bae5a47785e7d5c8cb2b54b2acdb9678315a17", size = 164315, upload-time = "2024-09-21T17:33:48.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5e/ffa234473e46ab2d3f9fd9858163d5db3ecea1439e4cb52966d78906424b/websockets-13.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e54affdeb21026329fb0744ad187cf812f7d3c2aa702a5edb562b325191fcab6", size = 163714, upload-time = "2024-09-21T17:33:49.548Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/92/cea9eb9d381ca57065a5eb4ec2ce7a291bd96c85ce742915c3c9ffc1069f/websockets-13.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9ef8aa8bdbac47f4968a5d66462a2a0935d044bf35c0e5a8af152d58516dbeb5", size = 163673, upload-time = "2024-09-21T17:33:51.056Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f1/279104fff239bfd04c12b1e58afea227d72fd1acf431e3eed3f6ac2c96d2/websockets-13.1-cp39-cp39-win32.whl", hash = "sha256:deeb929efe52bed518f6eb2ddc00cc496366a14c726005726ad62c2dd9017a3c", size = 158702, upload-time = "2024-09-21T17:33:52.584Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0b/b87370ff141375c41f7dd67941728e4b3682ebb45882591516c792a2ebee/websockets-13.1-cp39-cp39-win_amd64.whl", hash = "sha256:7c65ffa900e7cc958cd088b9a9157a8141c991f8c53d11087e6fb7277a03f81d", size = 159146, upload-time = "2024-09-21T17:33:53.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/75/6da22cb3ad5b8c606963f9a5f9f88656256fecc29d420b4b2bf9e0c7d56f/websockets-13.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5dd6da9bec02735931fccec99d97c29f47cc61f644264eb995ad6c0c27667238", size = 155499, upload-time = "2024-09-21T17:33:54.917Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ba/22833d58629088fcb2ccccedfae725ac0bbcd713319629e97125b52ac681/websockets-13.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:2510c09d8e8df777177ee3d40cd35450dc169a81e747455cc4197e63f7e7bfe5", size = 155737, upload-time = "2024-09-21T17:33:56.052Z" },
+    { url = "https://files.pythonhosted.org/packages/95/54/61684fe22bdb831e9e1843d972adadf359cf04ab8613285282baea6a24bb/websockets-13.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1c3cf67185543730888b20682fb186fc8d0fa6f07ccc3ef4390831ab4b388d9", size = 157095, upload-time = "2024-09-21T17:33:57.21Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f5/6652fb82440813822022a9301a30afde85e5ff3fb2aebb77f34aabe2b4e8/websockets-13.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcc03c8b72267e97b49149e4863d57c2d77f13fae12066622dc78fe322490fe6", size = 156701, upload-time = "2024-09-21T17:33:59.061Z" },
+    { url = "https://files.pythonhosted.org/packages/67/33/ae82a7b860fa8a08aba68818bdf7ff61f04598aa5ab96df4cd5a3e418ca4/websockets-13.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:004280a140f220c812e65f36944a9ca92d766b6cc4560be652a0a3883a79ed8a", size = 156654, upload-time = "2024-09-21T17:34:00.944Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0b/a1b528d36934f833e20f6da1032b995bf093d55cb416b9f2266f229fb237/websockets-13.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e2620453c075abeb0daa949a292e19f56de518988e079c36478bacf9546ced23", size = 159192, upload-time = "2024-09-21T17:34:02.656Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a1/5ae6d0ef2e61e2b77b3b4678949a634756544186620a728799acdf5c3482/websockets-13.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9156c45750b37337f7b0b00e6248991a047be4aa44554c9886fe6bdd605aab3b", size = 155433, upload-time = "2024-09-21T17:34:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2f/addd33f85600d210a445f817ff0d79d2b4d0eb6f3c95b9f35531ebf8f57c/websockets-13.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:80c421e07973a89fbdd93e6f2003c17d20b69010458d3a8e37fb47874bd67d51", size = 155733, upload-time = "2024-09-21T17:34:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0b/f8ec74ac3b14a983289a1b42dc2c518a0e2030b486d0549d4f51ca11e7c9/websockets-13.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82d0ba76371769d6a4e56f7e83bb8e81846d17a6190971e38b5de108bde9b0d7", size = 157093, upload-time = "2024-09-21T17:34:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4c/aa5cc2f718ee4d797411202f332c8281f04c42d15f55b02f7713320f7a03/websockets-13.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9875a0143f07d74dc5e1ded1c4581f0d9f7ab86c78994e2ed9e95050073c94d", size = 156701, upload-time = "2024-09-21T17:34:07.582Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4b/7c5b2d0d0f0f1a54f27c60107cf1f201bee1f88c5508f87408b470d09a9c/websockets-13.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a11e38ad8922c7961447f35c7b17bffa15de4d17c70abd07bfbe12d6faa3e027", size = 156648, upload-time = "2024-09-21T17:34:08.734Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/63/35f3fb073884a9fd1ce5413b2dcdf0d9198b03dac6274197111259cbde06/websockets-13.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4059f790b6ae8768471cddb65d3c4fe4792b0ab48e154c9f0a04cefaabcd5978", size = 159188, upload-time = "2024-09-21T17:34:10.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fd/e4bf9a7159dba6a16c59ae9e670e3e8ad9dcb6791bc0599eb86de32d50a9/websockets-13.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:25c35bf84bf7c7369d247f0b8cfa157f989862c49104c5cf85cb5436a641d93e", size = 155499, upload-time = "2024-09-21T17:34:11.3Z" },
+    { url = "https://files.pythonhosted.org/packages/74/42/d48ede93cfe0c343f3b552af08efc60778d234989227b16882eed1b8b189/websockets-13.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:83f91d8a9bb404b8c2c41a707ac7f7f75b9442a0a876df295de27251a856ad09", size = 155731, upload-time = "2024-09-21T17:34:13.151Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f2/2ef6bff1c90a43b80622a17c0852b48c09d3954ab169266ad7b15e17cdcb/websockets-13.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a43cfdcddd07f4ca2b1afb459824dd3c6d53a51410636a2c7fc97b9a8cf4842", size = 157093, upload-time = "2024-09-21T17:34:14.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/6f20bbaeeb350f155edf599aad949c554216f90e5d4ae7373d1f2e5931fb/websockets-13.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48a2ef1381632a2f0cb4efeff34efa97901c9fbc118e01951ad7cfc10601a9bb", size = 156701, upload-time = "2024-09-21T17:34:15.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/38279dfefecd035e22b79c38722d4f87c4b6196f1556b7a631d0a3095ca7/websockets-13.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459bf774c754c35dbb487360b12c5727adab887f1622b8aed5755880a21c4a20", size = 156649, upload-time = "2024-09-21T17:34:17.335Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c5/12c6859a2eaa8c53f59a647617a27f1835a226cd7106c601067c53251d98/websockets-13.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:95858ca14a9f6fa8413d29e0a585b31b278388aa775b8a81fa24830123874678", size = 159187, upload-time = "2024-09-21T17:34:18.538Z" },
+    { url = "https://files.pythonhosted.org/packages/56/27/96a5cd2626d11c8280656c6c71d8ab50fe006490ef9971ccd154e0c42cd2/websockets-13.1-py3-none-any.whl", hash = "sha256:a9a396a6ad26130cdae92ae10c36af09d9bfe6cafe69670fd3b6da9b07b4044f", size = 152134, upload-time = "2024-09-21T17:34:19.904Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/36/db/3fff0bcbe339a6fa6a3b9e3fbc2bfb321ec2f4cd233692272c5a8d6cf801/websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5", size = 175424, upload-time = "2025-03-05T20:02:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e6/519054c2f477def4165b0ec060ad664ed174e140b0d1cbb9fafa4a54f6db/websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a", size = 173077, upload-time = "2025-03-05T20:02:58.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/21/c0712e382df64c93a0d16449ecbf87b647163485ca1cc3f6cbadb36d2b03/websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b", size = 173324, upload-time = "2025-03-05T20:02:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cb/51ba82e59b3a664df54beed8ad95517c1b4dc1a913730e7a7db778f21291/websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770", size = 182094, upload-time = "2025-03-05T20:03:01.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0f/bf3788c03fec679bcdaef787518dbe60d12fe5615a544a6d4cf82f045193/websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb", size = 181094, upload-time = "2025-03-05T20:03:03.123Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/da/9fb8c21edbc719b66763a571afbaf206cb6d3736d28255a46fc2fe20f902/websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054", size = 181397, upload-time = "2025-03-05T20:03:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/65/65f379525a2719e91d9d90c38fe8b8bc62bd3c702ac651b7278609b696c4/websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee", size = 181794, upload-time = "2025-03-05T20:03:06.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/26/31ac2d08f8e9304d81a1a7ed2851c0300f636019a57cbaa91342015c72cc/websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed", size = 181194, upload-time = "2025-03-05T20:03:08.844Z" },
+    { url = "https://files.pythonhosted.org/packages/98/72/1090de20d6c91994cd4b357c3f75a4f25ee231b63e03adea89671cc12a3f/websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880", size = 181164, upload-time = "2025-03-05T20:03:10.242Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/37/098f2e1c103ae8ed79b0e77f08d83b0ec0b241cf4b7f2f10edd0126472e1/websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411", size = 176381, upload-time = "2025-03-05T20:03:12.77Z" },
+    { url = "https://files.pythonhosted.org/packages/75/8b/a32978a3ab42cebb2ebdd5b05df0696a09f4d436ce69def11893afa301f0/websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4", size = 176841, upload-time = "2025-03-05T20:03:14.367Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/48/4b67623bac4d79beb3a6bb27b803ba75c1bdedc06bd827e465803690a4b2/websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940", size = 173106, upload-time = "2025-03-05T20:03:29.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f0/adb07514a49fe5728192764e04295be78859e4a537ab8fcc518a3dbb3281/websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e", size = 173339, upload-time = "2025-03-05T20:03:30.755Z" },
+    { url = "https://files.pythonhosted.org/packages/87/28/bd23c6344b18fb43df40d0700f6d3fffcd7cef14a6995b4f976978b52e62/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9", size = 174597, upload-time = "2025-03-05T20:03:32.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/79/ca288495863d0f23a60f546f0905ae8f3ed467ad87f8b6aceb65f4c013e4/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b", size = 174205, upload-time = "2025-03-05T20:03:33.731Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e4/120ff3180b0872b1fe6637f6f995bcb009fb5c87d597c1fc21456f50c848/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f", size = 174150, upload-time = "2025-03-05T20:03:35.757Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c3/30e2f9c539b8da8b1d76f64012f3b19253271a63413b2d3adb94b143407f/websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123", size = 176877, upload-time = "2025-03-05T20:03:37.199Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -4,4 +4,5 @@ requires-python = ">=3.8"
 
 [[package]]
 name = "automerge"
+version = "0.2.0.dev1"
 source = { editable = "." }


### PR DESCRIPTION
## Add S3 Storage Adapter

This PR adds an S3 storage adapter that implements the `Storage` protocol, enabling automerge documents to be persisted in Amazon S3.

### Features

- **S3Storage class** implementing `load`, `load_range`, `put`, and `delete` methods
- **Async operations** using `aiobotocore` for non-blocking S3 access
- **Per-request client pattern** for automatic resource cleanup (no explicit `close()` needed)
- **Configurable concurrency** via `max_concurrent_requests` parameter (default: 50) to prevent overwhelming S3 with parallel requests
- **Key prefixing** support for multi-tenant scenarios (e.g., `prefix="users/user-123"`)
- **Flexible credentials** - supports explicit credentials or falls back to the default AWS credential chain

### Installation

```bash
pip install automerge[s3]
```

### Usage

```python
from automerge.storages.s3 import S3Storage
from automerge.repo import Repo

storage = S3Storage(
    bucket="my-bucket",
    region="us-east-1",
    prefix="users/user-123",
)
repo = await Repo.load(storage)
```

### Testing

Tests require AWS credentials and environment variables:

```bash
export S3_BUCKET_NAME=my-test-bucket
export AWS_REGION=us-east-1
export S3_TEST_PREFIX=my-test-folder
pytest tests/test_s3_storage.py -v
```