### PR TITLE
Add heads() and view(heads) to DocHandle

### DIFF
--- a/src/automerge/repo.py
+++ b/src/automerge/repo.py
@@ -1428,6 +1428,20 @@ class DocHandle:
         """
         return self._document_id
 
+    def _get_core_doc(self):
+        """Get the underlying core Document from the document actor.
+
+        Returns:
+            The Rust-backed core Document for this handle.
+
+        Raises:
+            ValueError: If the document actor has been removed from the repo.
+        """
+        actor = self._repo._doc_actors.get(self._actor_id)
+        if actor is None:
+            raise ValueError(f"Document actor {self._actor_id} not found")
+        return actor.get_document()
+
     def doc(self):
         """Return a read-only view of the document.
 
@@ -1450,16 +1464,36 @@ class DocHandle:
 
         from .document import MapReadProxy
 
-        # Get the document actor
-        actor = self._repo._doc_actors.get(self._actor_id)
-        if actor is None:
-            raise ValueError(f"Document actor {self._actor_id} not found")
+        return MapReadProxy(self._get_core_doc(), core.ROOT, None)
 
-        # Get the actor-backed document
-        core_doc = actor.get_document()
+    def heads(self) -> list[bytes]:
+        """Return the current heads of the document.
 
-        # Wrap in MapReadProxy for Pythonic dict-like access
-        return MapReadProxy(core_doc, core.ROOT, None)
+        Heads identify the current state of the document as a list of
+        change hashes. They can be saved and later passed to view() to
+        get a read-only snapshot of the document at that point in time.
+
+        Returns:
+            The current heads as a list of raw change hashes.
+        """
+        return self._get_core_doc().get_heads()
+
+    def view(self, heads: list[bytes]):
+        """Return a read-only view of the document at specific heads.
+
+        Args:
+            heads: A list of change hashes identifying the document
+                state to view, as returned by heads().
+
+        Returns:
+            MapReadProxy: A dict-like read-only view of the document
+            at the requested heads.
+        """
+        import automerge.core as core
+
+        from .document import MapReadProxy
+
+        return MapReadProxy(self._get_core_doc(), core.ROOT, heads)
 
     def change(self) -> ChangeContext:
         """Return a context manager for modifying the document.

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1954,6 +1954,105 @@ async def test_context_cleanup_on_error():
 
 
 @pytest.mark.asyncio
+async def test_doc_handle_heads():
+    """Test that heads() returns change hashes tracking document state."""
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Empty document should still return a valid heads list
+        heads_empty = handle.heads()
+        assert isinstance(heads_empty, list)
+
+        # Make a change and let IO tasks settle
+        with handle.change() as doc:
+            doc["key"] = "value1"
+        await asyncio.sleep(0.1)
+
+        # Heads should now contain exactly one change hash (single linear history)
+        heads_after_first = handle.heads()
+        assert len(heads_after_first) == 1
+        assert isinstance(heads_after_first[0], bytes)
+        assert heads_after_first != heads_empty
+
+        # Make a second change
+        with handle.change() as doc:
+            doc["key"] = "value2"
+        await asyncio.sleep(0.1)
+
+        # Heads should have advanced to a new hash
+        heads_after_second = handle.heads()
+        assert len(heads_after_second) == 1
+        assert heads_after_second != heads_after_first
+
+
+@pytest.mark.asyncio
+async def test_doc_handle_view_at_heads():
+    """Test that view(heads) returns a snapshot at the requested state."""
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Set counter to 1 and capture heads
+        with handle.change() as doc:
+            doc["counter"] = 1
+        await asyncio.sleep(0.1)
+
+        heads_v1 = handle.heads()
+
+        # Update counter to 2 and capture new heads
+        with handle.change() as doc:
+            doc["counter"] = 2
+        await asyncio.sleep(0.1)
+
+        heads_v2 = handle.heads()
+
+        # Viewing at v1 heads should return the old value
+        snapshot_v1 = handle.view(heads_v1)
+        assert snapshot_v1["counter"] == 1
+
+        # Viewing at v2 heads should return the updated value
+        snapshot_v2 = handle.view(heads_v2)
+        assert snapshot_v2["counter"] == 2
+
+        # doc() without heads should match the latest state
+        current = handle.doc()
+        assert current["counter"] == 2
+
+
+@pytest.mark.asyncio
+async def test_doc_handle_view_preserves_nested():
+    """Test that view(heads) works with nested document structures."""
+    storage = InMemoryStorage()
+    repo = await Repo.load(storage)
+
+    async with repo:
+        handle = await repo.create()
+
+        # Create a nested map and capture heads
+        with handle.change() as doc:
+            doc["config"] = {"version": 1}
+        await asyncio.sleep(0.1)
+
+        heads_v1 = handle.heads()
+
+        # Mutate the nested map: update an existing key and add a new one
+        with handle.change() as doc:
+            doc["config"]["version"] = 2
+            doc["config"]["extra"] = "added"
+        await asyncio.sleep(0.1)
+
+        # Snapshot at v1 should see the original nested state
+        snapshot = handle.view(heads_v1)
+        assert snapshot["config"]["version"] == 1
+        assert "extra" not in list(snapshot["config"].keys())
+
+
+@pytest.mark.asyncio
 async def test_context_cleanup_after_success():
     """Test that context is cleaned up after successful change block."""
     from automerge.repo import InMemoryStorage


### PR DESCRIPTION
## Summary

- Add `DocHandle.heads()` to return the current document heads as `list[bytes]`
- Add `DocHandle.view(heads)` to return a read-only `MapReadProxy` at a historical state
- Extract shared `_get_core_doc()` helper to deduplicate actor lookup across `doc()`, `heads()`, and `view()`

The underlying `core.Document.get_heads()` and heads-aware `MapReadProxy` already exist -- this change exposes them through `DocHandle` so callers don't need to reach into private `_doc_actors` internals.

Zero Rust changes. Pure Python layer addition (~25 lines of implementation).

## Test plan

- [x] `test_doc_handle_heads` -- verifies heads change after mutations and are `list[bytes]`
- [x] `test_doc_handle_view_at_heads` -- verifies snapshot at prior heads returns old values
- [x] `test_doc_handle_view_preserves_nested` -- verifies nested objects are correctly scoped to requested heads
- [x] Full `test_repo.py` suite passes (65 tests)


Made with [Cursor](https://cursor.com)