### PR TITLE
Add extra_headers support to WebSocketClientTransport.connect

### DIFF
--- a/src/automerge/transports/websocket.py
+++ b/src/automerge/transports/websocket.py
@@ -60,11 +60,15 @@ class WebSocketClientTransport:
         self._closed = False
 
     @classmethod
-    async def connect(cls, uri: str) -> "WebSocketClientTransport":
+    async def connect(
+        cls, uri: str, *, extra_headers=None
+    ) -> "WebSocketClientTransport":
         """Connect to a WebSocket server.
 
         Args:
             uri: The WebSocket URI to connect to (e.g., "ws://localhost:8080")
+            extra_headers: Optional headers to include in the WebSocket handshake
+                (e.g., {"Authorization": "Bearer <token>"})
 
         Returns:
             A connected WebSocketClientTransport instance
@@ -73,7 +77,7 @@ class WebSocketClientTransport:
             >>> transport = await WebSocketClientTransport.connect("ws://localhost:8080")
             >>> await repo.connect(transport)
         """
-        websocket = await connect(uri)
+        websocket = await connect(uri, extra_headers=extra_headers)
         return cls(websocket)
 
     async def send(self, msg: bytes):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -344,3 +344,41 @@ async def test_websocket_binary_message_validation():
 
             await transport.close()
             await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_connect_with_extra_headers():
+    """Test that extra_headers can be passed to WebSocketClientTransport.connect."""
+    storage_a = InMemoryStorage()
+    storage_b = InMemoryStorage()
+
+    repo_a = await Repo.load(storage_a)
+    repo_b = await Repo.load(storage_b)
+
+    async with repo_a, repo_b:
+        async with WebSocketServer(repo_b, "localhost", 8775):
+            await asyncio.sleep(0.1)
+
+            # Connect with extra headers
+            transport = await WebSocketClientTransport.connect(
+                "ws://localhost:8775",
+                extra_headers={"Authorization": "Bearer test-token"},
+            )
+            _conn_task = asyncio.create_task(repo_a.connect(transport))
+            await asyncio.sleep(0.5)
+
+            # Create a document and verify sync works with extra headers
+            handle_a = await repo_a.create()
+
+            with handle_a.change() as doc:
+                doc["auth"] = "yes"
+            await asyncio.sleep(0.5)
+
+            handle_b = await repo_b.find(handle_a.url)
+            assert handle_b is not None, "Document should have synced to server"
+
+            doc_b = handle_b.doc()
+            assert doc_b["auth"] == "yes"
+
+            await transport.close()
+            await asyncio.sleep(0.1)


### PR DESCRIPTION
## Summary
- Add optional `extra_headers` keyword argument to `WebSocketClientTransport.connect()`, passed through to `websockets.client.connect`
- Enables connecting to auth-protected sync servers by passing headers like `Authorization` during the WebSocket handshake
- Add test verifying connections with extra headers work correctly

## Test plan
- [x] New test `test_websocket_connect_with_extra_headers` passes
- [x] Ruff lint and format checks pass
- [ ] Existing WebSocket tests still pass (no breaking changes — `extra_headers` defaults to `None`)