### PR TITLE
fix: classify bool before int in _infer_scalar_type

### DIFF
--- a/src/automerge/document.py
+++ b/src/automerge/document.py
@@ -557,12 +557,12 @@ def _infer_scalar_type(value: core.ScalarValue) -> core.ScalarType:
         return core.ScalarType.Str
     elif isinstance(value, bytes):
         return core.ScalarType.Bytes
+    elif isinstance(value, bool):
+        return core.ScalarType.Boolean
     elif isinstance(value, int):
         return core.ScalarType.Int
     elif isinstance(value, float):
         return core.ScalarType.F64
-    elif isinstance(value, bool):
-        return core.ScalarType.Boolean
     elif isinstance(value, datetime):
         return core.ScalarType.Timestamp
     elif value is None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -42,3 +42,12 @@ def test_iterable() -> None:
     assert len(doc["map"]) == 2
     assert list(doc["map"]) == ["k", "x"]
     assert list(doc["map"].items()) == [("k", "v"), ("x", "y")]
+
+
+def test_bool_round_trip() -> None:
+    doc = Document()
+    with doc.change() as c:
+        c["flag"] = True
+        c["off"] = False
+    assert doc["flag"] is True
+    assert doc["off"] is False


### PR DESCRIPTION
Python's bool is a subclass of int, so isinstance(True, int) is True. The previous branch order matched booleans against the int branch first and stored them as ScalarType.Int, causing True/False to round-trip back as 1/0 rather than bool.

Move the bool branch above int. Add a regression test that asserts True/False round-trip with identity preserved.

fixes #25 